### PR TITLE
docs: clarify large artifact context tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,10 @@ Routine live operations are not repository feature work:
 - **MUST** ask before creating any public GitHub artifact when a task could be interpreted as either repository work or live operations.
 - **MUST NOT** include private infrastructure details, secrets, API keys, or user-specific operational data in GitHub issues, comments, PRs, or commit messages.
 
+## AI Context Tools
+
+For very large non-source artifacts such as CI logs, debug traces, generated JSON, or massive command output, agents may optionally use `chopratejas/headroom` or a similar local compression tool as a navigation aid, but must verify conclusions against the original uncompressed artifact before editing code or making final claims.
+
 ## Core MUST Rules
 
 ### Environment Setup


### PR DESCRIPTION
## Summary
- Add AGENTS.md guidance for optional local compression helpers such as chopratejas/headroom when navigating very large non-source artifacts.
- Keep the source-of-truth guardrail: agents must verify conclusions against the original uncompressed artifact before editing code or making final claims.

## Verification
- git diff --check

No build or test run: documentation-only AGENTS.md change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent guidance; no runtime, auth, or application code affected.
> 
> **Overview**
> Adds an **AI Context Tools** section to `AGENTS.md` between the GitHub Issues rules and **Core MUST Rules**. It tells agents they may use optional local helpers (e.g. `chopratejas/headroom`) when skimming very large non-source artifacts (CI logs, traces, huge command output), and that they **must** confirm anything that affects code or final statements against the original uncompressed data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f03509edf82e3159032597f658bf613410902fe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent guidelines for improved handling and verification of large artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->