### PR TITLE
perf: import pkc-js via the slim ./client entry

### DIFF
--- a/src/cli/base-command.ts
+++ b/src/cli/base-command.ts
@@ -1,6 +1,6 @@
 import { Command, Flags } from "@oclif/core";
 import defaults from "../common-utils/defaults.js";
-import PKC from "@pkcprotocol/pkc-js";
+import PKC from "@pkcprotocol/pkc-js/client";
 import { PKCLogger, setupDebugLogger, type PKCLoggerType } from "../util.js";
 type PKCInstance = Awaited<ReturnType<typeof PKC>>;
 type PKCConnectOverride = (pkcRpcUrl: string) => Promise<PKCInstance>;


### PR DESCRIPTION
## What

`BaseCommand._connectToPkcRpc()` is RPC-only — it always constructs
`PKC({ pkcRpcClientsOptions: [pkcRpcUrl] })` and never starts a local node. Switch its import from
`@pkcprotocol/pkc-js` to the new slim `@pkcprotocol/pkc-js/client` export, which defers the
local-node / signer / kubo-rpc-client / undici / thumbnail graphs behind lazy imports.

One-line change (`src/cli/base-command.ts`).

## Impact

On a slow production host the pkc-js import drops from ~1.97s to ~1.22s; `community list -q` end to
end from ~3.34s to ~2.6s.

## ⚠️ Blocked

The `./client` export does not exist in the currently published `@pkcprotocol/pkc-js` (0.0.62). This
PR must not merge until pkc-js ships it — see pkcprotocol/pkc-js#178 (pkcprotocol/pkc-js#179) — and
the `@pkcprotocol/pkc-js` dependency here is bumped to that release. Opening as a draft to track.
