### PR TITLE
chore(deps): upgrade @pkcprotocol/pkc-js 0.0.77 -> 0.0.81

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@oclif/plugin-help": "6.2.36",
                 "@oclif/plugin-not-found": "3.2.73",
                 "@oclif/table": "0.5.1",
-                "@pkcprotocol/pkc-js": "0.0.77",
+                "@pkcprotocol/pkc-js": "0.0.81",
                 "dataobject-parser": "1.2.22",
                 "decompress": "4.2.1",
                 "env-paths": "2.2.1",
@@ -5850,9 +5850,9 @@
             }
         },
         "node_modules/@pkcprotocol/pkc-js": {
-            "version": "0.0.77",
-            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.77.tgz",
-            "integrity": "sha512-Tl9LGf14BGfQCZJowtTNMI722MtRwEqmFmeVuhnI6Er6mj48Ap2gVPQvF3nDK5fWvFxes5dDsLfUVFz0njH3UQ==",
+            "version": "0.0.81",
+            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.81.tgz",
+            "integrity": "sha512-mUgk+Dg6HPm9xAtPQVB+GBK8WJd8SgGpMg0QhW9aingOzh/jl3uNkJoycOJP7oF4I/L5bkPb19hPZHn8fohM4g==",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@enhances/with-resolvers": "0.0.5",
@@ -5906,7 +5906,6 @@
                 "retry": "0.13.1",
                 "rpc-websockets": "9.3.8",
                 "safe-stable-stringify": "2.4.3",
-                "tcp-port-used": "1.0.2",
                 "tiny-typed-emitter": "2.1.0",
                 "tinycache": "1.1.2",
                 "ts-custom-error": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "@oclif/plugin-help": "6.2.36",
         "@oclif/plugin-not-found": "3.2.73",
         "@oclif/table": "0.5.1",
-        "@pkcprotocol/pkc-js": "0.0.77",
+        "@pkcprotocol/pkc-js": "0.0.81",
         "dataobject-parser": "1.2.22",
         "decompress": "4.2.1",
         "env-paths": "2.2.1",


### PR DESCRIPTION
Closes #122

## What

Bumps `@pkcprotocol/pkc-js` from `0.0.77` to `0.0.81` (latest). Dependency-only change — no source edits.

## Upstream changes

**v0.0.78** — no user-facing changes.

**v0.0.79**
- fix(helia): detach `peer:update` listener when the provider stream throws (pkcprotocol/pkc-js#256)
- fix(kubo): run repo GC hourly per daemon instead of on a StorageMax watermark (pkcprotocol/pkc-js#259)

**v0.0.80**
- feat(community): delegated records advertise their anchor; claim-first `nameResolved` (pkcprotocol/pkc-js#260)

**v0.0.81**
- fix(kubo): pin the pubsub topic block in the `block.put` call so a repo gc cannot delete it
- fix(kubo): remove the address rewriter proxy that now degrades provider records (pkcprotocol/pkc-js#263)

## Verification

- `npm run build && npm run build:test` — clean
- `npm run test:cli` — 41 files, 319 passed, 1 skipped

## Follow-up worth a look (not changed here)

pkc-js 0.0.79 added its own repo GC schedule in `local-community/cleanup.js`: `cleanUpIpfsRepoIfDue` runs at the end of every community sync with a 1-hour-per-kubo-RPC-URL floor, single-flighted by kubo URL.

This repo added `startRepoGcScheduler` (`src/ipfs/repoGc.ts`, wired in `src/cli/commands/daemon.ts:744`) in 6757a87, which drives an independent hourly `repo/gc` over the same RPC. The two schedulers don't know about each other, so on a daemon hosting communities the effective sweep rate roughly doubles and two full sweeps can overlap. pkc-js's own comment notes that since kubo 0.43.0 GC and in-flight MFS writes hold each other off, so overlapping sweeps are not free.

They are not exactly redundant, though: pkc-js only GCs as a side effect of a community sync, so a bitsocial daemon hosting zero communities (a seed-only node) would never GC if ours were removed. Deciding whether to drop, gate, or keep our scheduler is a behaviour change, so it is left out of this dependency bump — filing separately if you want it addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PKC JavaScript dependency to version 0.0.81 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->