### PR TITLE
fix(challenge): reload replaced challenge packages instead of cached ESM modules (#124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,13 +328,14 @@ Install a challenge package (npm package name, git URL, tarball URL, or local pa
 
 ```
 USAGE
-  $ bitsocial challenge add PACKAGE [--pkcOptions.dataPath <value>]
+  $ bitsocial challenge add PACKAGE --pkcRpcUrl <value> [--pkcOptions.dataPath <value>]
 
 ARGUMENTS
   PACKAGE  Package specifier — anything npm can install (name, name@version, git URL, tarball URL, local path)
 
 FLAGS
   --pkcOptions.dataPath=<value>  Data path to install the challenge into
+  --pkcRpcUrl=<value>            (required) [default: ws://localhost:9138/] URL to PKC RPC
 
 DESCRIPTION
   Install a challenge package (npm package name, git URL, tarball URL, or local path)
@@ -361,13 +362,14 @@ Install a challenge package (npm package name, git URL, tarball URL, or local pa
 
 ```
 USAGE
-  $ bitsocial challenge i PACKAGE [--pkcOptions.dataPath <value>]
+  $ bitsocial challenge i PACKAGE --pkcRpcUrl <value> [--pkcOptions.dataPath <value>]
 
 ARGUMENTS
   PACKAGE  Package specifier — anything npm can install (name, name@version, git URL, tarball URL, local path)
 
 FLAGS
   --pkcOptions.dataPath=<value>  Data path to install the challenge into
+  --pkcRpcUrl=<value>            (required) [default: ws://localhost:9138/] URL to PKC RPC
 
 DESCRIPTION
   Install a challenge package (npm package name, git URL, tarball URL, or local path)
@@ -394,13 +396,14 @@ Install a challenge package (npm package name, git URL, tarball URL, or local pa
 
 ```
 USAGE
-  $ bitsocial challenge install PACKAGE [--pkcOptions.dataPath <value>]
+  $ bitsocial challenge install PACKAGE --pkcRpcUrl <value> [--pkcOptions.dataPath <value>]
 
 ARGUMENTS
   PACKAGE  Package specifier — anything npm can install (name, name@version, git URL, tarball URL, local path)
 
 FLAGS
   --pkcOptions.dataPath=<value>  Data path to install the challenge into
+  --pkcRpcUrl=<value>            (required) [default: ws://localhost:9138/] URL to PKC RPC
 
 DESCRIPTION
   Install a challenge package (npm package name, git URL, tarball URL, or local path)
@@ -479,13 +482,14 @@ Remove an installed challenge package
 
 ```
 USAGE
-  $ bitsocial challenge remove NAME [--pkcOptions.dataPath <value>]
+  $ bitsocial challenge remove NAME --pkcRpcUrl <value> [--pkcOptions.dataPath <value>]
 
 ARGUMENTS
   NAME  The challenge package name (e.g., my-challenge or @scope/my-challenge)
 
 FLAGS
   --pkcOptions.dataPath=<value>  Data path where challenges are installed
+  --pkcRpcUrl=<value>            (required) [default: ws://localhost:9138/] URL to PKC RPC
 
 DESCRIPTION
   Remove an installed challenge package
@@ -509,13 +513,14 @@ Remove an installed challenge package
 
 ```
 USAGE
-  $ bitsocial challenge rm NAME [--pkcOptions.dataPath <value>]
+  $ bitsocial challenge rm NAME --pkcRpcUrl <value> [--pkcOptions.dataPath <value>]
 
 ARGUMENTS
   NAME  The challenge package name (e.g., my-challenge or @scope/my-challenge)
 
 FLAGS
   --pkcOptions.dataPath=<value>  Data path where challenges are installed
+  --pkcRpcUrl=<value>            (required) [default: ws://localhost:9138/] URL to PKC RPC
 
 DESCRIPTION
   Remove an installed challenge package
@@ -537,13 +542,14 @@ Remove an installed challenge package
 
 ```
 USAGE
-  $ bitsocial challenge un NAME [--pkcOptions.dataPath <value>]
+  $ bitsocial challenge un NAME --pkcRpcUrl <value> [--pkcOptions.dataPath <value>]
 
 ARGUMENTS
   NAME  The challenge package name (e.g., my-challenge or @scope/my-challenge)
 
 FLAGS
   --pkcOptions.dataPath=<value>  Data path where challenges are installed
+  --pkcRpcUrl=<value>            (required) [default: ws://localhost:9138/] URL to PKC RPC
 
 DESCRIPTION
   Remove an installed challenge package
@@ -565,13 +571,14 @@ Remove an installed challenge package
 
 ```
 USAGE
-  $ bitsocial challenge uninstall NAME [--pkcOptions.dataPath <value>]
+  $ bitsocial challenge uninstall NAME --pkcRpcUrl <value> [--pkcOptions.dataPath <value>]
 
 ARGUMENTS
   NAME  The challenge package name (e.g., my-challenge or @scope/my-challenge)
 
 FLAGS
   --pkcOptions.dataPath=<value>  Data path where challenges are installed
+  --pkcRpcUrl=<value>            (required) [default: ws://localhost:9138/] URL to PKC RPC
 
 DESCRIPTION
   Remove an installed challenge package
@@ -883,7 +890,7 @@ FLAGS
                                   https://eth.drpc.org,https://ethereum.publicnode.com,https://ethereum-rpc.publicnode.c
                                   om,https://rpc.mevblocker.io,https://1rpc.io/eth,https://eth-pokt.nodies.app] RPC
                                   URL(s) for .bso name resolution. Can be specified multiple times.
-  --logPath=<value>               (required) [default: /home/runner/.local/state/bitsocial] Specify a directory which
+  --logPath=<value>               (required) [default: /home/user2/.local/state/bitsocial] Specify a directory which
                                   will be used to store logs
   --pkcRpcUrl=<value>             (required) [default: ws://localhost:9138/] Specify PKC RPC URL to listen on
 

--- a/src/challenge-packages/challenge-utils.ts
+++ b/src/challenge-packages/challenge-utils.ts
@@ -348,10 +348,12 @@ export async function reloadChallengesInDaemon(pkcRpcUrl: string | URL): Promise
 }
 
 // Hash of a challenge package's own source, used as the import cache key (see
-// loadChallengesIntoPKC).  node_modules and dot-entries are skipped: dependencies are
-// pinned by the install that produced this package dir, and hashing them would make
-// every reload walk the entire dependency tree.
-async function hashChallengePackageContents(challengeDir: string): Promise<string> {
+// loadChallengesIntoPKC).  Only node_modules is skipped: dependencies are pinned by the
+// install that produced this package dir, and hashing them would make every reload walk
+// the entire dependency tree.  Dot-prefixed files and directories are hashed — pkg.main
+// may point into one (".dist/index.js"), and skipping them left that entry out of the key,
+// so a same-version replacement kept the old import URL and served the stale module.
+export async function hashChallengePackageContents(challengeDir: string): Promise<string> {
     const hash = createHash("sha256");
 
     const walk = async (dir: string, relativeDir: string): Promise<void> => {
@@ -359,14 +361,18 @@ async function hashChallengePackageContents(challengeDir: string): Promise<strin
         // Sort so the digest does not depend on readdir order
         entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
         for (const entry of entries) {
-            if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+            if (entry.name === "node_modules") continue;
             const absolutePath = path.join(dir, entry.name);
             const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
             if (entry.isDirectory()) {
                 await walk(absolutePath, relativePath);
             } else if (entry.isFile()) {
-                hash.update(relativePath);
-                hash.update(await fs.readFile(absolutePath));
+                // Frame each record: feeding the path and the raw bytes back to back makes the
+                // stream ambiguous, so {index.js:"A", j:"Z"} and {index.js:"AjZ"} would hash
+                // identically and a changed entry could reuse the previous cache key
+                const contents = await fs.readFile(absolutePath);
+                const fileDigest = createHash("sha256").update(contents).digest("hex");
+                hash.update(`${relativePath}\0${fileDigest}\0`);
             }
         }
     };

--- a/src/challenge-packages/challenge-utils.ts
+++ b/src/challenge-packages/challenge-utils.ts
@@ -331,19 +331,26 @@ export function challengeReloadUrlFromPkcRpcUrl(pkcRpcUrl: string): string | und
     return `http://${host.includes(":") ? `[${host}]` : host}:${url.port}/api/challenges/reload`;
 }
 
+/** How long install/remove wait for a daemon to finish reloading before giving up. */
+export const CHALLENGE_RELOAD_TIMEOUT_MS = 30000;
+
 /**
  * Ask the daemon at `pkcRpcUrl` to reload its challenge packages, so an install/remove takes
  * effect without a restart. Returns whether a daemon actually reloaded — best-effort, since
  * no daemon running is not an error.
+ *
+ * The request is bounded: a daemon that accepts the connection but never answers (busy, wedged,
+ * or something else listening on the port) would otherwise hold the CLI for undici's 300s
+ * default. Aborting only ends our wait — the daemon may still finish the reload.
  */
-export async function reloadChallengesInDaemon(pkcRpcUrl: string | URL): Promise<boolean> {
+export async function reloadChallengesInDaemon(pkcRpcUrl: string | URL, timeoutMs = CHALLENGE_RELOAD_TIMEOUT_MS): Promise<boolean> {
     const reloadUrl = challengeReloadUrlFromPkcRpcUrl(pkcRpcUrl.toString());
     if (!reloadUrl) return false;
     try {
-        const res = await fetch(reloadUrl, { method: "POST" });
+        const res = await fetch(reloadUrl, { method: "POST", signal: AbortSignal.timeout(timeoutMs) });
         return res.ok;
     } catch {
-        return false; // daemon not running, that's fine
+        return false; // daemon not running or not answering, that's fine
     }
 }
 
@@ -381,11 +388,37 @@ export async function hashChallengePackageContents(challengeDir: string): Promis
     return hash.digest("hex").slice(0, 16);
 }
 
+/**
+ * What each challenge name held in PKC.challenges before this process first registered a package
+ * under it.  PKC.challenges *is* pkc-js's own registry, so a package named after a built-in
+ * ("question") shadows it — unregistering has to hand the built-in back rather than delete the
+ * key.  `hadPrevious: false` means the name was ours alone and can be deleted.
+ *
+ * A process serves one data path (the daemon passes its own), so this is not keyed by data path.
+ */
+const shadowedChallenges = new Map<string, { hadPrevious: boolean; previous: unknown }>();
+
 export async function loadChallengesIntoPKC(dataPath?: string): Promise<InstalledChallenge[]> {
     const challenges = await listInstalledChallenges(dataPath);
-    if (challenges.length === 0) return [];
 
     const PKC = await import("@pkcprotocol/pkc-js");
+    const registry = (PKC.default as any).challenges as Record<string, unknown>;
+
+    // Hand back any name whose package is no longer installed, so `challenge remove` takes effect
+    // without a restart.  A package that is still installed but fails to import keeps its
+    // previously loaded factory: it is excluded from the returned list either way, and dropping a
+    // working challenge because its replacement is broken would take the community's publication
+    // flow down instead of leaving it on known-good code.
+    const installedNames = new Set(challenges.map((challenge) => challenge.name));
+    for (const [name, original] of shadowedChallenges) {
+        if (installedNames.has(name)) continue;
+        if (original.hadPrevious) registry[name] = original.previous;
+        else delete registry[name];
+        shadowedChallenges.delete(name);
+    }
+
+    if (challenges.length === 0) return [];
+
     const loaded: InstalledChallenge[] = [];
 
     for (const challenge of challenges) {
@@ -410,7 +443,12 @@ export async function loadChallengesIntoPKC(dataPath?: string): Promise<Installe
 
             const imported = await import(entryUrl.href);
             const factory = imported.default || imported;
-            (PKC.default as any).challenges[challenge.name] = factory;
+            // Remember what this name held before we first took it over, so `challenge remove`
+            // can hand it back instead of leaving a dead key (or deleting a pkc-js built-in)
+            if (!shadowedChallenges.has(challenge.name)) {
+                shadowedChallenges.set(challenge.name, { hadPrevious: challenge.name in registry, previous: registry[challenge.name] });
+            }
+            registry[challenge.name] = factory;
             loaded.push(challenge);
         } catch (err) {
             console.error(`Failed to load challenge "${challenge.name}":`, err);

--- a/src/challenge-packages/challenge-utils.ts
+++ b/src/challenge-packages/challenge-utils.ts
@@ -6,7 +6,6 @@ import type { Dirent } from "fs";
 import { execFileSync, spawn } from "child_process";
 import defaults from "../common-utils/defaults.js";
 import { migrateDataDirectory } from "../common-utils/data-migration.js";
-import { getAliveDaemonStates } from "../common-utils/daemon-state.js";
 
 export interface InstalledChallenge {
     name: string;
@@ -312,10 +311,10 @@ export function formatChallengeNameVersion(challenge: Pick<InstalledChallenge, "
 }
 
 /**
- * HTTP origin of a daemon's challenge-reload endpoint, derived from the ws:// RPC url it
- * recorded in its state file. The reload endpoint is served by the same http server as the
- * RPC socket, and its local-only variant requires the request to come from the loopback
- * interface — so a wildcard bind is dialed as loopback rather than as 0.0.0.0.
+ * HTTP url of a daemon's challenge-reload endpoint, derived from its --pkcRpcUrl. The endpoint
+ * is served by the same http server as the RPC socket, and its local-only variant requires the
+ * request to come from the loopback interface — so a wildcard bind is dialed as loopback rather
+ * than as 0.0.0.0.
  */
 export function challengeReloadUrlFromPkcRpcUrl(pkcRpcUrl: string): string | undefined {
     let url: URL;
@@ -333,63 +332,19 @@ export function challengeReloadUrlFromPkcRpcUrl(pkcRpcUrl: string): string | und
 }
 
 /**
- * Data path a running daemon was started with, read back from the argv in its state file.
- * A daemon started without the flag uses the default data path.
+ * Ask the daemon at `pkcRpcUrl` to reload its challenge packages, so an install/remove takes
+ * effect without a restart. Returns whether a daemon actually reloaded — best-effort, since
+ * no daemon running is not an error.
  */
-export function dataPathFromDaemonArgv(argv: string[]): string {
-    const flag = "--pkcOptions.dataPath";
-    for (let i = 0; i < argv.length; i++) {
-        const arg = argv[i]!;
-        if (arg === flag) {
-            const value = argv[i + 1];
-            if (value !== undefined && !value.startsWith("-")) return value;
-        } else if (arg.startsWith(`${flag}=`)) {
-            return arg.slice(flag.length + 1);
-        }
-    }
-    return defaults.PKC_DATA_PATH;
-}
-
-/**
- * Ask every running daemon that serves `dataPath` to reload its challenge packages, so an
- * install/remove takes effect without a restart.  Best-effort: a daemon that is not running,
- * or is mid-shutdown, is not an error.
- *
- * Daemons are discovered through their state files rather than assumed to be on the default
- * RPC port — a daemon started with --pkcRpcUrl would otherwise never be reached.  Daemons
- * serving a different data path are left alone: their challenges dir did not change.
- * When no state files exist at all (a daemon predating them), the default RPC url is tried
- * so the previous behavior still holds.
- */
-export async function reloadChallengesInRunningDaemons(dataPath: string): Promise<number> {
-    let reloadUrls: string[];
+export async function reloadChallengesInDaemon(pkcRpcUrl: string | URL): Promise<boolean> {
+    const reloadUrl = challengeReloadUrlFromPkcRpcUrl(pkcRpcUrl.toString());
+    if (!reloadUrl) return false;
     try {
-        const aliveDaemons = await getAliveDaemonStates();
-        if (aliveDaemons.length === 0) {
-            reloadUrls = [challengeReloadUrlFromPkcRpcUrl(defaults.PKC_RPC_URL.toString())!];
-        } else {
-            const resolvedDataPath = path.resolve(dataPath);
-            reloadUrls = aliveDaemons
-                .filter((state) => path.resolve(dataPathFromDaemonArgv(state.argv)) === resolvedDataPath)
-                .map((state) => challengeReloadUrlFromPkcRpcUrl(state.pkcRpcUrl))
-                .filter((url): url is string => url !== undefined);
-        }
+        const res = await fetch(reloadUrl, { method: "POST" });
+        return res.ok;
     } catch {
-        // Unreadable state dir — fall back to the default RPC url
-        reloadUrls = [challengeReloadUrlFromPkcRpcUrl(defaults.PKC_RPC_URL.toString())!];
+        return false; // daemon not running, that's fine
     }
-
-    const results = await Promise.all(
-        [...new Set(reloadUrls)].map(async (url) => {
-            try {
-                const res = await fetch(url, { method: "POST" });
-                return res.ok;
-            } catch {
-                return false; // daemon not running, that's fine
-            }
-        })
-    );
-    return results.filter(Boolean).length;
 }
 
 // Hash of a challenge package's own source, used as the import cache key (see

--- a/src/challenge-packages/challenge-utils.ts
+++ b/src/challenge-packages/challenge-utils.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 import fs from "fs/promises";
 import type { Dirent } from "fs";
@@ -309,6 +310,34 @@ export function formatChallengeNameVersion(challenge: Pick<InstalledChallenge, "
     return challenge.version && challenge.version !== "unknown" ? `${challenge.name}@${challenge.version}` : challenge.name;
 }
 
+// Hash of a challenge package's own source, used as the import cache key (see
+// loadChallengesIntoPKC).  node_modules and dot-entries are skipped: dependencies are
+// pinned by the install that produced this package dir, and hashing them would make
+// every reload walk the entire dependency tree.
+async function hashChallengePackageContents(challengeDir: string): Promise<string> {
+    const hash = createHash("sha256");
+
+    const walk = async (dir: string, relativeDir: string): Promise<void> => {
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+        // Sort so the digest does not depend on readdir order
+        entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+        for (const entry of entries) {
+            if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+            const absolutePath = path.join(dir, entry.name);
+            const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+            if (entry.isDirectory()) {
+                await walk(absolutePath, relativePath);
+            } else if (entry.isFile()) {
+                hash.update(relativePath);
+                hash.update(await fs.readFile(absolutePath));
+            }
+        }
+    };
+
+    await walk(challengeDir, "");
+    return hash.digest("hex").slice(0, 16);
+}
+
 export async function loadChallengesIntoPKC(dataPath?: string): Promise<InstalledChallenge[]> {
     const challenges = await listInstalledChallenges(dataPath);
     if (challenges.length === 0) return [];
@@ -322,7 +351,21 @@ export async function loadChallengesIntoPKC(dataPath?: string): Promise<Installe
             // Resolve the entry point
             const entryPoint = pkg.main || "index.js";
             const entryPath = path.resolve(challenge.path, entryPoint);
-            const imported = await import(pathToFileURL(entryPath).href);
+
+            // Node caches ESM modules by URL, and `challenge install` swaps a new build onto
+            // the same destination path.  Importing the bare path would therefore hand back
+            // the module evaluated before the upgrade, so the registry would keep serving the
+            // old factory while metadata reports the new version (issue #124).  Keying the URL
+            // on the package contents re-evaluates the entry whenever the package changes and
+            // stays byte-identical (so cached, so factory-identical) when it does not.
+            //
+            // Only the entry module is re-evaluated: relative imports inside the package do not
+            // inherit the query, so a multi-file package graph would keep its stale submodules.
+            // Challenge packages are expected to ship a bundled entry point.
+            const entryUrl = pathToFileURL(entryPath);
+            entryUrl.searchParams.set("bitsocialChallengeContent", await hashChallengePackageContents(challenge.path));
+
+            const imported = await import(entryUrl.href);
             const factory = imported.default || imported;
             (PKC.default as any).challenges[challenge.name] = factory;
             loaded.push(challenge);

--- a/src/challenge-packages/challenge-utils.ts
+++ b/src/challenge-packages/challenge-utils.ts
@@ -6,6 +6,7 @@ import type { Dirent } from "fs";
 import { execFileSync, spawn } from "child_process";
 import defaults from "../common-utils/defaults.js";
 import { migrateDataDirectory } from "../common-utils/data-migration.js";
+import { getAliveDaemonStates } from "../common-utils/daemon-state.js";
 
 export interface InstalledChallenge {
     name: string;
@@ -308,6 +309,87 @@ export async function verifyNativeModuleAbi(challengeDir: string): Promise<void>
 
 export function formatChallengeNameVersion(challenge: Pick<InstalledChallenge, "name" | "version">): string {
     return challenge.version && challenge.version !== "unknown" ? `${challenge.name}@${challenge.version}` : challenge.name;
+}
+
+/**
+ * HTTP origin of a daemon's challenge-reload endpoint, derived from the ws:// RPC url it
+ * recorded in its state file. The reload endpoint is served by the same http server as the
+ * RPC socket, and its local-only variant requires the request to come from the loopback
+ * interface — so a wildcard bind is dialed as loopback rather than as 0.0.0.0.
+ */
+export function challengeReloadUrlFromPkcRpcUrl(pkcRpcUrl: string): string | undefined {
+    let url: URL;
+    try {
+        url = new URL(pkcRpcUrl);
+    } catch {
+        return undefined;
+    }
+    if (!url.port) return undefined;
+    // URL.hostname keeps the brackets around an IPv6 literal — strip them so the host can be
+    // compared and re-bracketed exactly once
+    const hostname = url.hostname.replace(/^\[|\]$/g, "");
+    const host = hostname === "0.0.0.0" || hostname === "::" ? "127.0.0.1" : hostname;
+    return `http://${host.includes(":") ? `[${host}]` : host}:${url.port}/api/challenges/reload`;
+}
+
+/**
+ * Data path a running daemon was started with, read back from the argv in its state file.
+ * A daemon started without the flag uses the default data path.
+ */
+export function dataPathFromDaemonArgv(argv: string[]): string {
+    const flag = "--pkcOptions.dataPath";
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i]!;
+        if (arg === flag) {
+            const value = argv[i + 1];
+            if (value !== undefined && !value.startsWith("-")) return value;
+        } else if (arg.startsWith(`${flag}=`)) {
+            return arg.slice(flag.length + 1);
+        }
+    }
+    return defaults.PKC_DATA_PATH;
+}
+
+/**
+ * Ask every running daemon that serves `dataPath` to reload its challenge packages, so an
+ * install/remove takes effect without a restart.  Best-effort: a daemon that is not running,
+ * or is mid-shutdown, is not an error.
+ *
+ * Daemons are discovered through their state files rather than assumed to be on the default
+ * RPC port — a daemon started with --pkcRpcUrl would otherwise never be reached.  Daemons
+ * serving a different data path are left alone: their challenges dir did not change.
+ * When no state files exist at all (a daemon predating them), the default RPC url is tried
+ * so the previous behavior still holds.
+ */
+export async function reloadChallengesInRunningDaemons(dataPath: string): Promise<number> {
+    let reloadUrls: string[];
+    try {
+        const aliveDaemons = await getAliveDaemonStates();
+        if (aliveDaemons.length === 0) {
+            reloadUrls = [challengeReloadUrlFromPkcRpcUrl(defaults.PKC_RPC_URL.toString())!];
+        } else {
+            const resolvedDataPath = path.resolve(dataPath);
+            reloadUrls = aliveDaemons
+                .filter((state) => path.resolve(dataPathFromDaemonArgv(state.argv)) === resolvedDataPath)
+                .map((state) => challengeReloadUrlFromPkcRpcUrl(state.pkcRpcUrl))
+                .filter((url): url is string => url !== undefined);
+        }
+    } catch {
+        // Unreadable state dir — fall back to the default RPC url
+        reloadUrls = [challengeReloadUrlFromPkcRpcUrl(defaults.PKC_RPC_URL.toString())!];
+    }
+
+    const results = await Promise.all(
+        [...new Set(reloadUrls)].map(async (url) => {
+            try {
+                const res = await fetch(url, { method: "POST" });
+                return res.ok;
+            } catch {
+                return false; // daemon not running, that's fine
+            }
+        })
+    );
+    return results.filter(Boolean).length;
 }
 
 // Hash of a challenge package's own source, used as the import cache key (see

--- a/src/cli/commands/challenge/install.ts
+++ b/src/cli/commands/challenge/install.ts
@@ -1,4 +1,5 @@
-import { Args, Flags, Command } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { BaseCommand } from "../../base-command.js";
 import path from "path";
 import fs from "fs/promises";
 import decompress from "decompress";
@@ -11,10 +12,10 @@ import {
     runNpmPack,
     runNpmInstall,
     verifyNativeModuleAbi,
-    reloadChallengesInRunningDaemons
+    reloadChallengesInDaemon
 } from "../../../challenge-packages/challenge-utils.js";
 
-export default class Install extends Command {
+export default class Install extends BaseCommand {
     static override description = "Install a challenge package (npm package name, git URL, tarball URL, or local path)";
 
     static override aliases = ["challenge:i", "challenge:add"];
@@ -133,11 +134,10 @@ export default class Install extends Command {
             const elapsedSeconds = Math.max(1, Math.round((Date.now() - startTime) / 1000));
             this.log(`${alreadyExists ? "changed" : "added"} ${pkg.name}${version} in ${elapsedSeconds}s`);
 
-            // 10. Best-effort reload in every running daemon serving this data path, so the
-            //     install takes effect without a restart
-            const reloadedDaemonCount = await reloadChallengesInRunningDaemons(dataPath);
-            if (reloadedDaemonCount > 0) {
-                this.log(`reloaded ${pkg.name}${version} in ${reloadedDaemonCount} running daemon${reloadedDaemonCount === 1 ? "" : "s"}`);
+            // 10. Best-effort reload in the daemon at --pkcRpcUrl, so the install takes effect
+            //     without a restart
+            if (await reloadChallengesInDaemon(flags.pkcRpcUrl)) {
+                this.log(`reloaded ${pkg.name}${version} in the daemon at ${flags.pkcRpcUrl}`);
             }
         } finally {
             // 11. Clean up temp dir (includes the previous-install backup, if any)

--- a/src/cli/commands/challenge/install.ts
+++ b/src/cli/commands/challenge/install.ts
@@ -10,7 +10,8 @@ import {
     readChallengePackageJson,
     runNpmPack,
     runNpmInstall,
-    verifyNativeModuleAbi
+    verifyNativeModuleAbi,
+    reloadChallengesInRunningDaemons
 } from "../../../challenge-packages/challenge-utils.js";
 
 export default class Install extends Command {
@@ -132,11 +133,11 @@ export default class Install extends Command {
             const elapsedSeconds = Math.max(1, Math.round((Date.now() - startTime) / 1000));
             this.log(`${alreadyExists ? "changed" : "added"} ${pkg.name}${version} in ${elapsedSeconds}s`);
 
-            // 10. Best-effort reload via daemon
-            try {
-                await fetch("http://localhost:9138/api/challenges/reload", { method: "POST" });
-            } catch {
-                // daemon not running, that's fine
+            // 10. Best-effort reload in every running daemon serving this data path, so the
+            //     install takes effect without a restart
+            const reloadedDaemonCount = await reloadChallengesInRunningDaemons(dataPath);
+            if (reloadedDaemonCount > 0) {
+                this.log(`reloaded ${pkg.name}${version} in ${reloadedDaemonCount} running daemon${reloadedDaemonCount === 1 ? "" : "s"}`);
             }
         } finally {
             // 11. Clean up temp dir (includes the previous-install backup, if any)

--- a/src/cli/commands/challenge/remove.ts
+++ b/src/cli/commands/challenge/remove.ts
@@ -2,7 +2,12 @@ import { Args, Flags, Command } from "@oclif/core";
 import fs from "fs/promises";
 import path from "path";
 import defaults from "../../../common-utils/defaults.js";
-import { getChallengesDir, challengeNameToDir, readChallengePackageJson } from "../../../challenge-packages/challenge-utils.js";
+import {
+    getChallengesDir,
+    challengeNameToDir,
+    readChallengePackageJson,
+    reloadChallengesInRunningDaemons
+} from "../../../challenge-packages/challenge-utils.js";
 
 export default class Remove extends Command {
     static override description = "Remove an installed challenge package";
@@ -69,11 +74,8 @@ export default class Remove extends Command {
 
         this.log(`removed ${args.name}${version}`);
 
-        // Best-effort reload via daemon
-        try {
-            await fetch("http://localhost:9138/api/challenges/reload", { method: "POST" });
-        } catch {
-            // daemon not running, that's fine
-        }
+        // Best-effort reload in every running daemon serving this data path, so the
+        // removal takes effect without a restart
+        await reloadChallengesInRunningDaemons(dataPath);
     }
 }

--- a/src/cli/commands/challenge/remove.ts
+++ b/src/cli/commands/challenge/remove.ts
@@ -1,4 +1,5 @@
-import { Args, Flags, Command } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { BaseCommand } from "../../base-command.js";
 import fs from "fs/promises";
 import path from "path";
 import defaults from "../../../common-utils/defaults.js";
@@ -6,10 +7,10 @@ import {
     getChallengesDir,
     challengeNameToDir,
     readChallengePackageJson,
-    reloadChallengesInRunningDaemons
+    reloadChallengesInDaemon
 } from "../../../challenge-packages/challenge-utils.js";
 
-export default class Remove extends Command {
+export default class Remove extends BaseCommand {
     static override description = "Remove an installed challenge package";
 
     static override aliases = ["challenge:uninstall", "challenge:rm", "challenge:un"];
@@ -74,8 +75,8 @@ export default class Remove extends Command {
 
         this.log(`removed ${args.name}${version}`);
 
-        // Best-effort reload in every running daemon serving this data path, so the
-        // removal takes effect without a restart
-        await reloadChallengesInRunningDaemons(dataPath);
+        // Best-effort reload in the daemon at --pkcRpcUrl, so the removal takes effect
+        // without a restart
+        await reloadChallengesInDaemon(flags.pkcRpcUrl);
     }
 }

--- a/test/cli/challenge-daemon-reload-target.test.ts
+++ b/test/cli/challenge-daemon-reload-target.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import path from "path";
+import defaults from "../../src/common-utils/defaults.js";
+import { challengeReloadUrlFromPkcRpcUrl, dataPathFromDaemonArgv } from "../../src/challenge-packages/challenge-utils.js";
+
+// `challenge install` / `challenge remove` used to POST the reload endpoint at a hardcoded
+// localhost:9138, so a daemon started with --pkcRpcUrl never picked up an install without a
+// restart. Reload targets are now derived from the state files running daemons write.
+
+describe("challengeReloadUrlFromPkcRpcUrl", () => {
+    it("derives the reload endpoint from the daemon's RPC url", () => {
+        expect(challengeReloadUrlFromPkcRpcUrl("ws://localhost:9138")).toBe("http://localhost:9138/api/challenges/reload");
+    });
+
+    it("keeps a non-default port", () => {
+        expect(challengeReloadUrlFromPkcRpcUrl("ws://localhost:54321/")).toBe("http://localhost:54321/api/challenges/reload");
+    });
+
+    it("dials a wildcard bind as loopback so the local-only endpoint accepts the request", () => {
+        expect(challengeReloadUrlFromPkcRpcUrl("ws://0.0.0.0:9138")).toBe("http://127.0.0.1:9138/api/challenges/reload");
+        expect(challengeReloadUrlFromPkcRpcUrl("ws://[::]:9138")).toBe("http://127.0.0.1:9138/api/challenges/reload");
+    });
+
+    it("brackets IPv6 hosts", () => {
+        expect(challengeReloadUrlFromPkcRpcUrl("ws://[::1]:9138")).toBe("http://[::1]:9138/api/challenges/reload");
+    });
+
+    it("returns undefined for unusable urls", () => {
+        expect(challengeReloadUrlFromPkcRpcUrl("not a url")).toBeUndefined();
+        expect(challengeReloadUrlFromPkcRpcUrl("ws://localhost")).toBeUndefined(); // no port
+    });
+});
+
+describe("dataPathFromDaemonArgv", () => {
+    it("reads a space-separated flag", () => {
+        expect(dataPathFromDaemonArgv(["--pkcOptions.dataPath", "/tmp/data", "--pkcRpcUrl", "ws://localhost:1234"])).toBe("/tmp/data");
+    });
+
+    it("reads an =-separated flag", () => {
+        expect(dataPathFromDaemonArgv(["--pkcOptions.dataPath=/tmp/data"])).toBe("/tmp/data");
+    });
+
+    it("falls back to the default data path when the flag is absent", () => {
+        expect(dataPathFromDaemonArgv(["--pkcRpcUrl", "ws://localhost:1234"])).toBe(defaults.PKC_DATA_PATH);
+    });
+
+    it("does not treat a following flag as the value", () => {
+        expect(dataPathFromDaemonArgv(["--pkcOptions.dataPath", "--pkcRpcUrl"])).toBe(defaults.PKC_DATA_PATH);
+    });
+
+    it("resolves to the same path a matching install would compare against", () => {
+        const dataPath = "/tmp/some/data/";
+        expect(path.resolve(dataPathFromDaemonArgv(["--pkcOptions.dataPath", dataPath]))).toBe(path.resolve(dataPath));
+    });
+});

--- a/test/cli/challenge-daemon-reload-target.test.ts
+++ b/test/cli/challenge-daemon-reload-target.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect } from "vitest";
-import path from "path";
-import defaults from "../../src/common-utils/defaults.js";
-import { challengeReloadUrlFromPkcRpcUrl, dataPathFromDaemonArgv } from "../../src/challenge-packages/challenge-utils.js";
+import { challengeReloadUrlFromPkcRpcUrl } from "../../src/challenge-packages/challenge-utils.js";
 
 // `challenge install` / `challenge remove` used to POST the reload endpoint at a hardcoded
 // localhost:9138, so a daemon started with --pkcRpcUrl never picked up an install without a
-// restart. Reload targets are now derived from the state files running daemons write.
+// restart. The reload target is now derived from the command's own --pkcRpcUrl flag.
 
 describe("challengeReloadUrlFromPkcRpcUrl", () => {
     it("derives the reload endpoint from the daemon's RPC url", () => {
@@ -28,28 +26,5 @@ describe("challengeReloadUrlFromPkcRpcUrl", () => {
     it("returns undefined for unusable urls", () => {
         expect(challengeReloadUrlFromPkcRpcUrl("not a url")).toBeUndefined();
         expect(challengeReloadUrlFromPkcRpcUrl("ws://localhost")).toBeUndefined(); // no port
-    });
-});
-
-describe("dataPathFromDaemonArgv", () => {
-    it("reads a space-separated flag", () => {
-        expect(dataPathFromDaemonArgv(["--pkcOptions.dataPath", "/tmp/data", "--pkcRpcUrl", "ws://localhost:1234"])).toBe("/tmp/data");
-    });
-
-    it("reads an =-separated flag", () => {
-        expect(dataPathFromDaemonArgv(["--pkcOptions.dataPath=/tmp/data"])).toBe("/tmp/data");
-    });
-
-    it("falls back to the default data path when the flag is absent", () => {
-        expect(dataPathFromDaemonArgv(["--pkcRpcUrl", "ws://localhost:1234"])).toBe(defaults.PKC_DATA_PATH);
-    });
-
-    it("does not treat a following flag as the value", () => {
-        expect(dataPathFromDaemonArgv(["--pkcOptions.dataPath", "--pkcRpcUrl"])).toBe(defaults.PKC_DATA_PATH);
-    });
-
-    it("resolves to the same path a matching install would compare against", () => {
-        const dataPath = "/tmp/some/data/";
-        expect(path.resolve(dataPathFromDaemonArgv(["--pkcOptions.dataPath", dataPath]))).toBe(path.resolve(dataPath));
     });
 });

--- a/test/cli/challenge-daemon-reload-target.test.ts
+++ b/test/cli/challenge-daemon-reload-target.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { challengeReloadUrlFromPkcRpcUrl } from "../../src/challenge-packages/challenge-utils.js";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { challengeReloadUrlFromPkcRpcUrl, reloadChallengesInDaemon } from "../../src/challenge-packages/challenge-utils.js";
 
 // `challenge install` / `challenge remove` used to POST the reload endpoint at a hardcoded
 // localhost:9138, so a daemon started with --pkcRpcUrl never picked up an install without a
@@ -26,5 +28,49 @@ describe("challengeReloadUrlFromPkcRpcUrl", () => {
     it("returns undefined for unusable urls", () => {
         expect(challengeReloadUrlFromPkcRpcUrl("not a url")).toBeUndefined();
         expect(challengeReloadUrlFromPkcRpcUrl("ws://localhost")).toBeUndefined(); // no port
+    });
+});
+
+describe("reloadChallengesInDaemon", () => {
+    it("returns false when nothing is listening", async () => {
+        // Port 1 is privileged and unbound — connection is refused immediately
+        expect(await reloadChallengesInDaemon("ws://127.0.0.1:1", 5000)).toBe(false);
+    });
+
+    it("gives up on a daemon that accepts the request but never answers", async () => {
+        // Without a bounded request this waits for undici's 300s default, hanging the CLI
+        const server = createServer(() => {
+            /* accept the request, never respond */
+        });
+        await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+        const { port } = server.address() as AddressInfo;
+
+        try {
+            const startedAt = Date.now();
+            expect(await reloadChallengesInDaemon(`ws://127.0.0.1:${port}`, 300)).toBe(false);
+            expect(Date.now() - startedAt).toBeLessThan(5000);
+        } finally {
+            server.closeAllConnections();
+            await new Promise<void>((resolve) => server.close(() => resolve()));
+        }
+    });
+
+    it("reports a successful reload", async () => {
+        const server = createServer((req, res) => {
+            if (req.method === "POST" && req.url === "/api/challenges/reload") {
+                res.writeHead(200, { "content-type": "application/json" });
+                res.end(JSON.stringify({ ok: true, challenges: [] }));
+                return;
+            }
+            res.writeHead(404).end();
+        });
+        await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+        const { port } = server.address() as AddressInfo;
+
+        try {
+            expect(await reloadChallengesInDaemon(`ws://127.0.0.1:${port}`)).toBe(true);
+        } finally {
+            await new Promise<void>((resolve) => server.close(() => resolve()));
+        }
     });
 });

--- a/test/cli/challenge-integration.test.ts
+++ b/test/cli/challenge-integration.test.ts
@@ -426,9 +426,9 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
         });
 
         // `challenge install` reloads on its own. It used to POST a hardcoded localhost:9138,
-        // so a daemon on a non-default RPC port (like this one) never saw the install; targets
-        // now come from the state files running daemons write.
-        it("challenge install alone updates a running daemon on a non-default RPC port", { timeout: 180_000 }, async () => {
+        // so a daemon on a non-default RPC port (like this one) never saw the install; the
+        // reload target now comes from the command's own --pkcRpcUrl.
+        it("challenge install --pkcRpcUrl alone updates a daemon on a non-default RPC port", { timeout: 180_000 }, async () => {
             const sub = await pkc.createCommunity();
             await sub.edit({
                 settings: {
@@ -448,11 +448,18 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
                 });
 
                 // No explicit /api/challenges/reload call anywhere in this test — install must
-                // find this daemon by itself
-                const installResult = await runBitsocialChallenge(["install", v3SrcDir, "--pkcOptions.dataPath", dataPath]);
+                // reload the daemon at --pkcRpcUrl by itself
+                const installResult = await runBitsocialChallenge([
+                    "install",
+                    v3SrcDir,
+                    "--pkcOptions.dataPath",
+                    dataPath,
+                    "--pkcRpcUrl",
+                    rpcWsUrl
+                ]);
                 expect(installResult.exitCode).toBe(0);
                 expect(installResult.stdout).toContain("changed test-challenge@3.0.0 in");
-                expect(installResult.stdout).toContain("reloaded test-challenge@3.0.0 in 1 running daemon");
+                expect(installResult.stdout).toContain(`reloaded test-challenge@3.0.0 in the daemon at ${rpcWsUrl}`);
 
                 const result = await publishCommentWithChallenge({
                     pkc,

--- a/test/cli/challenge-integration.test.ts
+++ b/test/cli/challenge-integration.test.ts
@@ -207,7 +207,7 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
             });
             await sub.start();
             // Wait for community to publish its first IPNS record
-            await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500);
+            expect(await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500)).toBe(true);
         }, 120_000);
 
         afterAll(async () => {
@@ -263,7 +263,7 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
                 }
             });
             await sub.start();
-            await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500);
+            expect(await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500)).toBe(true);
         }, 120_000);
 
         afterAll(async () => {
@@ -324,7 +324,7 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
                 }
             });
             await sub.start();
-            await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500);
+            expect(await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500)).toBe(true);
 
             try {
                 const result = await publishCommentWithChallenge({
@@ -353,7 +353,7 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
                 }
             });
             await sub.start();
-            await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500);
+            expect(await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500)).toBe(true);
 
             try {
                 // v1 (installed in beforeAll) is active
@@ -436,7 +436,7 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
                 }
             });
             await sub.start();
-            await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500);
+            expect(await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500)).toBe(true);
 
             try {
                 const v3SrcDir = path.join(randomDirectory(), "test-challenge");

--- a/test/cli/challenge-integration.test.ts
+++ b/test/cli/challenge-integration.test.ts
@@ -342,5 +342,87 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
                 }
             }
         });
+
+        // Issue #124: replacing an already-imported package under the same name left the
+        // daemon running the old ESM module while reporting the new version.
+        it("upgrading an installed challenge in place takes effect without a daemon restart", { timeout: 180_000 }, async () => {
+            const sub = await pkc.createCommunity();
+            await sub.edit({
+                settings: {
+                    challenges: [{ name: "test-challenge" }]
+                }
+            });
+            await sub.start();
+            await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500);
+
+            try {
+                // v1 (installed in beforeAll) is active
+                const v1Result = await publishCommentWithChallenge({
+                    pkc,
+                    communityAddress: sub.address,
+                    challengeAnswer: "2"
+                });
+                expect(v1Result.challengeSuccess).toBe(true);
+                expect(v1Result.challengeText).toBe("1+1");
+
+                // Replace test-challenge with v2 — same package name, different behavior
+                const v2SrcDir = path.join(randomDirectory(), "test-challenge");
+                await createMinimalChallengeDir(v2SrcDir, "test-challenge", {
+                    version: "2.0.0",
+                    description: "A test challenge for integration tests",
+                    challenge: "3+3",
+                    answer: "6"
+                });
+
+                const installResult = await runBitsocialChallenge(["install", v2SrcDir, "--pkcOptions.dataPath", dataPath]);
+                expect(installResult.exitCode).toBe(0);
+                expect(installResult.stdout).toContain("changed test-challenge@2.0.0 in");
+
+                // Reload without restarting the daemon
+                const reloadRes = await fetch(`http://localhost:${RPC_PORT}/api/challenges/reload`, { method: "POST" });
+                expect(reloadRes.status).toBe(200);
+                const reloadBody = (await reloadRes.json()) as { ok: boolean; challenges: string[] };
+                expect(reloadBody.ok).toBe(true);
+                expect(reloadBody.challenges).toContain("test-challenge@2.0.0");
+                expect(reloadBody.challenges).not.toContain("test-challenge@1.0.0");
+
+                // The active factory must match the reported version
+                const v2Result = await publishCommentWithChallenge({
+                    pkc,
+                    communityAddress: sub.address,
+                    challengeAnswer: "6"
+                });
+                expect(v2Result.challengeText).toBe("3+3");
+                expect(v2Result.challengeSuccess).toBe(true);
+
+                // The old answer must no longer pass
+                const staleAnswerResult = await publishCommentWithChallenge({
+                    pkc,
+                    communityAddress: sub.address,
+                    challengeAnswer: "2"
+                });
+                expect(staleAnswerResult.challengeSuccess).toBe(false);
+
+                // Reloading again without changing anything keeps v2 active
+                const reloadAgainRes = await fetch(`http://localhost:${RPC_PORT}/api/challenges/reload`, { method: "POST" });
+                expect(reloadAgainRes.status).toBe(200);
+                const reloadAgainBody = (await reloadAgainRes.json()) as { ok: boolean; challenges: string[] };
+                expect(reloadAgainBody.challenges).toContain("test-challenge@2.0.0");
+
+                const afterIdempotentReload = await publishCommentWithChallenge({
+                    pkc,
+                    communityAddress: sub.address,
+                    challengeAnswer: "6"
+                });
+                expect(afterIdempotentReload.challengeText).toBe("3+3");
+                expect(afterIdempotentReload.challengeSuccess).toBe(true);
+            } finally {
+                try {
+                    await sub.stop();
+                } catch {
+                    /* ignore */
+                }
+            }
+        });
     });
 });

--- a/test/cli/challenge-integration.test.ts
+++ b/test/cli/challenge-integration.test.ts
@@ -424,5 +424,50 @@ describe("challenge integration tests", { timeout: 600_000 }, () => {
                 }
             }
         });
+
+        // `challenge install` reloads on its own. It used to POST a hardcoded localhost:9138,
+        // so a daemon on a non-default RPC port (like this one) never saw the install; targets
+        // now come from the state files running daemons write.
+        it("challenge install alone updates a running daemon on a non-default RPC port", { timeout: 180_000 }, async () => {
+            const sub = await pkc.createCommunity();
+            await sub.edit({
+                settings: {
+                    challenges: [{ name: "test-challenge" }]
+                }
+            });
+            await sub.start();
+            await waitForCondition(() => !!(sub as any).updatedAt, 60000, 500);
+
+            try {
+                const v3SrcDir = path.join(randomDirectory(), "test-challenge");
+                await createMinimalChallengeDir(v3SrcDir, "test-challenge", {
+                    version: "3.0.0",
+                    description: "A test challenge for integration tests",
+                    challenge: "5+5",
+                    answer: "10"
+                });
+
+                // No explicit /api/challenges/reload call anywhere in this test — install must
+                // find this daemon by itself
+                const installResult = await runBitsocialChallenge(["install", v3SrcDir, "--pkcOptions.dataPath", dataPath]);
+                expect(installResult.exitCode).toBe(0);
+                expect(installResult.stdout).toContain("changed test-challenge@3.0.0 in");
+                expect(installResult.stdout).toContain("reloaded test-challenge@3.0.0 in 1 running daemon");
+
+                const result = await publishCommentWithChallenge({
+                    pkc,
+                    communityAddress: sub.address,
+                    challengeAnswer: "10"
+                });
+                expect(result.challengeText).toBe("5+5");
+                expect(result.challengeSuccess).toBe(true);
+            } finally {
+                try {
+                    await sub.stop();
+                } catch {
+                    /* ignore */
+                }
+            }
+        });
     });
 });

--- a/test/cli/challenge-loader-module-cache.test.ts
+++ b/test/cli/challenge-loader-module-cache.test.ts
@@ -142,6 +142,73 @@ describe("loadChallengesIntoPKC module cache", { timeout: 60_000 }, () => {
     });
 });
 
+// loadChallengesIntoPKC only ever added to the registry, so a challenge stayed live after
+// `challenge remove` until the daemon restarted.
+describe("loadChallengesIntoPKC unregistering", { timeout: 60_000 }, () => {
+    it("unregisters a challenge whose package is gone", async () => {
+        const dataPath = randomDirectory();
+        const challengesDir = path.join(dataPath, "challenges");
+        await fsPromise.mkdir(challengesDir, { recursive: true });
+        await installChallengePackage(challengesDir, { version: "1.0.0", challenge: "1+1", answer: "2" });
+
+        await loadChallengesIntoPKC(dataPath);
+        expect(getLoadedFactory()).toBeDefined();
+
+        await fsPromise.rm(path.join(challengesDir, CHALLENGE_NAME), { recursive: true, force: true });
+        const loaded = await loadChallengesIntoPKC(dataPath);
+
+        expect(loaded).toEqual([]);
+        expect(getLoadedFactory()).toBeUndefined();
+    });
+
+    it("restores a shadowed pkc-js built-in instead of deleting it", async () => {
+        const dataPath = randomDirectory();
+        const challengesDir = path.join(dataPath, "challenges");
+        const builtInName = "question";
+        const builtInFactory = (PKC as any).challenges[builtInName];
+        expect(builtInFactory).toBeTypeOf("function");
+
+        const packageDir = path.join(challengesDir, builtInName);
+        await fsPromise.mkdir(packageDir, { recursive: true });
+        await fsPromise.writeFile(
+            path.join(packageDir, "package.json"),
+            JSON.stringify({ name: builtInName, version: "1.0.0", type: "module" }, null, 2)
+        );
+        await fsPromise.writeFile(
+            path.join(packageDir, "index.js"),
+            `export default function() {
+    return { type: 'text/plain', challenge: 'shadowed', getChallenge: async () => ({ challenge: 'shadowed', type: 'text/plain', verify: async () => ({ success: true }) }) };
+};
+`
+        );
+
+        await loadChallengesIntoPKC(dataPath);
+        expect((PKC as any).challenges[builtInName]).not.toBe(builtInFactory);
+
+        await fsPromise.rm(packageDir, { recursive: true, force: true });
+        await loadChallengesIntoPKC(dataPath);
+
+        expect((PKC as any).challenges[builtInName]).toBe(builtInFactory);
+    });
+
+    it("keeps the working factory when a replacement fails to import", async () => {
+        const dataPath = randomDirectory();
+        const challengesDir = path.join(dataPath, "challenges");
+        await fsPromise.mkdir(challengesDir, { recursive: true });
+        await installChallengePackage(challengesDir, { version: "1.0.0", challenge: "1+1", answer: "2" });
+        await loadChallengesIntoPKC(dataPath);
+
+        // Replace the entry with code that throws on evaluation
+        await fsPromise.writeFile(path.join(challengesDir, CHALLENGE_NAME, "index.js"), `throw new Error("broken challenge");\n`);
+        const loaded = await loadChallengesIntoPKC(dataPath);
+
+        // Excluded from the response, so it cannot claim a version it did not activate...
+        expect(loaded).toEqual([]);
+        // ...but the community keeps serving known-good code rather than losing the challenge
+        expect(getActiveChallengeText()).toBe("1+1");
+    });
+});
+
 describe("hashChallengePackageContents", () => {
     const writeFiles = async (dir: string, files: Record<string, string>): Promise<string> => {
         await fsPromise.rm(dir, { recursive: true, force: true });

--- a/test/cli/challenge-loader-module-cache.test.ts
+++ b/test/cli/challenge-loader-module-cache.test.ts
@@ -3,7 +3,7 @@ import { directory as randomDirectory } from "tempy";
 import fsPromise from "fs/promises";
 import path from "path";
 import PKC from "@pkcprotocol/pkc-js";
-import { loadChallengesIntoPKC } from "../../src/challenge-packages/challenge-utils.js";
+import { loadChallengesIntoPKC, hashChallengePackageContents } from "../../src/challenge-packages/challenge-utils.js";
 
 // Issue #124: loadChallengesIntoPKC() imports every package from the same entry URL on
 // every reload. Node caches ESM modules by URL, so replacing a package in place (what
@@ -101,5 +101,83 @@ describe("loadChallengesIntoPKC module cache", { timeout: 60_000 }, () => {
         expect(await verifyWithActiveChallenge("8")).toBe(true);
         // Unchanged contents must not create a fresh module instance on every reload
         expect(getLoadedFactory()).toBe(factoryAfterFirstLoad);
+    });
+
+    // The content key skipped dot-prefixed entries, so a package whose pkg.main points into a
+    // dot directory kept its old import URL across a same-version replacement — the version
+    // never changes either, so nothing busted the cache and the stale module stayed active.
+    it("activates new code when a dot-path entry is replaced at the same version", async () => {
+        const dataPath = randomDirectory();
+        const challengeDir = path.join(dataPath, "challenges", CHALLENGE_NAME);
+
+        const installDotPathEntry = async (challenge: string): Promise<void> => {
+            await fsPromise.rm(challengeDir, { recursive: true, force: true });
+            await fsPromise.mkdir(path.join(challengeDir, ".dist"), { recursive: true });
+            await fsPromise.writeFile(
+                path.join(challengeDir, "package.json"),
+                JSON.stringify({ name: CHALLENGE_NAME, version: "1.0.0", type: "module", main: ".dist/index.js" }, null, 2)
+            );
+            await fsPromise.writeFile(
+                path.join(challengeDir, ".dist", "index.js"),
+                `export default function() {
+    return {
+        type: 'text/plain',
+        challenge: '${challenge}',
+        getChallenge: async () => ({ challenge: '${challenge}', type: 'text/plain', verify: async () => ({ success: true }) })
+    };
+};
+`
+            );
+        };
+
+        await installDotPathEntry("1+1");
+        await loadChallengesIntoPKC(dataPath);
+        expect(getActiveChallengeText()).toBe("1+1");
+
+        // Same version, new entry contents — `challenge install` allows this (reinstall replaces
+        // content even when the version is unchanged)
+        await installDotPathEntry("3+3");
+        await loadChallengesIntoPKC(dataPath);
+        expect(getActiveChallengeText()).toBe("3+3");
+    });
+});
+
+describe("hashChallengePackageContents", () => {
+    const writeFiles = async (dir: string, files: Record<string, string>): Promise<string> => {
+        await fsPromise.rm(dir, { recursive: true, force: true });
+        for (const [relativePath, contents] of Object.entries(files)) {
+            const filePath = path.join(dir, relativePath);
+            await fsPromise.mkdir(path.dirname(filePath), { recursive: true });
+            await fsPromise.writeFile(filePath, contents);
+        }
+        return dir;
+    };
+
+    it("distinguishes contents that share a concatenated byte stream", async () => {
+        // Hashing `path` then raw `contents` back to back is ambiguous: these two package
+        // states feed the identical stream "index.js" "A" "j" "Z" vs "index.js" "AjZ"
+        const root = randomDirectory();
+        const split = await writeFiles(path.join(root, "split"), { "index.js": "A", j: "Z" });
+        const merged = await writeFiles(path.join(root, "merged"), { "index.js": "AjZ" });
+
+        expect(await hashChallengePackageContents(split)).not.toBe(await hashChallengePackageContents(merged));
+    });
+
+    it("is stable for identical contents and changes when a file changes", async () => {
+        const root = randomDirectory();
+        const first = await writeFiles(path.join(root, "first"), { "index.js": "A", "lib/helper.js": "B" });
+        const same = await writeFiles(path.join(root, "same"), { "index.js": "A", "lib/helper.js": "B" });
+        const changed = await writeFiles(path.join(root, "changed"), { "index.js": "A", "lib/helper.js": "C" });
+
+        expect(await hashChallengePackageContents(first)).toBe(await hashChallengePackageContents(same));
+        expect(await hashChallengePackageContents(first)).not.toBe(await hashChallengePackageContents(changed));
+    });
+
+    it("ignores node_modules so reloads do not walk the dependency tree", async () => {
+        const root = randomDirectory();
+        const withoutDeps = await writeFiles(path.join(root, "without"), { "index.js": "A" });
+        const withDeps = await writeFiles(path.join(root, "with"), { "index.js": "A", "node_modules/dep/index.js": "anything" });
+
+        expect(await hashChallengePackageContents(withoutDeps)).toBe(await hashChallengePackageContents(withDeps));
     });
 });

--- a/test/cli/challenge-loader-module-cache.test.ts
+++ b/test/cli/challenge-loader-module-cache.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { directory as randomDirectory } from "tempy";
+import fsPromise from "fs/promises";
+import path from "path";
+import PKC from "@pkcprotocol/pkc-js";
+import { loadChallengesIntoPKC } from "../../src/challenge-packages/challenge-utils.js";
+
+// Issue #124: loadChallengesIntoPKC() imports every package from the same entry URL on
+// every reload. Node caches ESM modules by URL, so replacing a package in place (what
+// `bitsocial challenge install` does for an already-installed name) leaves the daemon
+// running the previously evaluated module even though package.json reports the new version.
+
+const CHALLENGE_NAME = "test-challenge-module-cache";
+
+const writeChallengePackage = async (
+    dir: string,
+    opts: { version: string; challenge: string; answer: string }
+): Promise<void> => {
+    await fsPromise.mkdir(dir, { recursive: true });
+    await fsPromise.writeFile(
+        path.join(dir, "package.json"),
+        JSON.stringify({ name: CHALLENGE_NAME, version: opts.version, type: "module" }, null, 2)
+    );
+    await fsPromise.writeFile(
+        path.join(dir, "index.js"),
+        `export default function() {
+    return {
+        type: 'text/plain',
+        challenge: '${opts.challenge}',
+        getChallenge: async () => ({
+            challenge: '${opts.challenge}',
+            type: 'text/plain',
+            verify: async (answer) => ({ success: answer === '${opts.answer}' })
+        })
+    };
+};
+`
+    );
+};
+
+// Replace the installed package the same way `challenge install` does: build the new
+// version elsewhere, then swap it into the destination path (same path, new contents).
+const installChallengePackage = async (
+    challengesDir: string,
+    opts: { version: string; challenge: string; answer: string }
+): Promise<void> => {
+    const destDir = path.join(challengesDir, CHALLENGE_NAME);
+    const stagingDir = path.join(challengesDir, `.staging-${opts.version}`);
+    await writeChallengePackage(stagingDir, opts);
+    await fsPromise.rm(destDir, { recursive: true, force: true });
+    await fsPromise.rename(stagingDir, destDir);
+};
+
+const getLoadedFactory = () => (PKC as any).challenges[CHALLENGE_NAME];
+
+const getActiveChallengeText = (): string => getLoadedFactory()({ challengeSettings: { name: CHALLENGE_NAME } }).challenge;
+
+const verifyWithActiveChallenge = async (answer: string): Promise<boolean> => {
+    const challengeFile = getLoadedFactory()({ challengeSettings: { name: CHALLENGE_NAME } });
+    const challenge = await challengeFile.getChallenge();
+    return (await challenge.verify(answer)).success;
+};
+
+describe("loadChallengesIntoPKC module cache", { timeout: 60_000 }, () => {
+    it("activates the new code when a package is replaced under the same name", async () => {
+        const dataPath = randomDirectory();
+        const challengesDir = path.join(dataPath, "challenges");
+        await fsPromise.mkdir(challengesDir, { recursive: true });
+
+        // v1 installed and loaded
+        await installChallengePackage(challengesDir, { version: "1.0.0", challenge: "1+1", answer: "2" });
+        const firstLoad = await loadChallengesIntoPKC(dataPath);
+        expect(firstLoad.map((c) => `${c.name}@${c.version}`)).toEqual([`${CHALLENGE_NAME}@1.0.0`]);
+        expect(getActiveChallengeText()).toBe("1+1");
+        expect(await verifyWithActiveChallenge("2")).toBe(true);
+
+        // v2 replaces it at the same path, then a reload happens (no process restart)
+        await installChallengePackage(challengesDir, { version: "2.0.0", challenge: "3+3", answer: "6" });
+        const secondLoad = await loadChallengesIntoPKC(dataPath);
+
+        // The reported version and the active factory must agree
+        expect(secondLoad.map((c) => `${c.name}@${c.version}`)).toEqual([`${CHALLENGE_NAME}@2.0.0`]);
+        expect(getActiveChallengeText()).toBe("3+3");
+        expect(await verifyWithActiveChallenge("6")).toBe(true);
+        expect(await verifyWithActiveChallenge("2")).toBe(false);
+    });
+
+    it("keeps behavior stable when reloading unchanged package contents", async () => {
+        const dataPath = randomDirectory();
+        const challengesDir = path.join(dataPath, "challenges");
+        await fsPromise.mkdir(challengesDir, { recursive: true });
+
+        await installChallengePackage(challengesDir, { version: "1.0.0", challenge: "4+4", answer: "8" });
+        await loadChallengesIntoPKC(dataPath);
+        const factoryAfterFirstLoad = getLoadedFactory();
+
+        await loadChallengesIntoPKC(dataPath);
+        await loadChallengesIntoPKC(dataPath);
+
+        expect(getActiveChallengeText()).toBe("4+4");
+        expect(await verifyWithActiveChallenge("8")).toBe(true);
+        // Unchanged contents must not create a fresh module instance on every reload
+        expect(getLoadedFactory()).toBe(factoryAfterFirstLoad);
+    });
+});


### PR DESCRIPTION
Fixes the stale-module bug in #124: a challenge upgraded under an existing name kept running the old code until the daemon was restarted, while `challenge list` and `POST /api/challenges/reload` both reported the new version.

## Root cause

`loadChallengesIntoPKC()` imported every installed package from a stable entry URL:

```ts
const imported = await import(pathToFileURL(entryPath).href);
```

Node caches ESM modules by URL, and `challenge install` renames a verified build onto the *same* destination path for an already-installed name. A reload therefore re-read the new `package.json` for metadata but reassigned the **previously evaluated** factory into `PKC.challenges[name]` — version and behavior disagreed until restart.

No pkc-js change was needed, as the issue predicted: `resolveChallengeFactoryByName()` reads `pkc.settings.challenges[name] ?? pkcJsChallenges[name]` on every challenge request, and `PKC.challenges` *is* that shared registry, so a running community picks up a replaced factory as soon as the registry is updated. The ESM cache was the only thing in the way.

## Fix

Import the entry under a URL keyed on a sha256 of the package's own source (`node_modules` and dot-entries excluded — dependencies are pinned by the install that produced the package dir, and hashing them would make every reload walk the whole dependency tree):

```ts
const entryUrl = pathToFileURL(entryPath);
entryUrl.searchParams.set("bitsocialChallengeContent", await hashChallengePackageContents(challenge.path));
const imported = await import(entryUrl.href);
```

- Package contents change → new key → the entry is re-evaluated.
- Package contents unchanged → byte-identical key → cached → **same factory identity**, so repeated reloads stay idempotent. This is why the key is content-derived rather than a nonce.
- An import failure still leaves the challenge out of the reload response, so the response cannot claim a version whose factory did not activate.

**Known constraint (documented at the import site):** only the entry module is re-evaluated — relative imports inside a package do not inherit the query, so a multi-file package graph would keep stale submodules. Challenge packages are expected to ship a bundled entry point, which the maintained Bitsocial packages do. Fully hot-reloading arbitrary graphs would need a generation-specific real path (i.e. copying the package per generation), which is not worth the cost today.

## Tests

Committed **before** the fix (`0237f02`), so the red→green transition is visible in the branch history.

**`test/cli/challenge-loader-module-cache.test.ts`** (new, ~0.4s, no daemon)

- Loads v1, swaps the package directory for v2 at the same path the installer uses, reloads, and asserts the active factory matches the reported version.
- Asserts reloading unchanged contents does **not** create a new module instance (`getLoadedFactory()` is identity-stable) — this guards against a naive nonce-based fix.

**`test/cli/challenge-integration.test.ts`** — the regression test described in the issue

- Exercises `test-challenge@1.0.0` against a running daemon.
- Installs `test-challenge@2.0.0` under the same name with different challenge text/answer, then `POST /api/challenges/reload`.
- Asserts the reload response reports v2, a publication exercises v2 behavior with no restart, the stale v1 answer now fails, and a repeat reload keeps v2 active.

Both failed with `expected '1+1' to be '3+3'` before the fix (after passing the assertion that the reload response reports `test-challenge@2.0.0` — exactly the disagreement in the issue) and pass after.

Full suite locally: **41 files, 313 passed, 1 skipped**.

Closes #124

---

## Second fix: the reload target comes from `--pkcRpcUrl`

Checking whether `bitsocial challenge install <newer-version>` actually updates a running daemon *immediately* turned up a second path to the same stale-code symptom, independent of the module cache.

`install.ts` and `remove.ts` fired their best-effort reload at a hardcoded url:

```ts
await fetch("http://localhost:9138/api/challenges/reload", { method: "POST" });
```

So a daemon started with `--pkcRpcUrl` (any non-default port) never learned about an install and kept serving the old challenge until restarted.

Both commands now extend `BaseCommand`, which already declares the `--pkcRpcUrl` flag every `community` command uses, and derive the reload endpoint from it — same flag, same default (`ws://localhost:9138`), so the common case is unchanged and a daemon on another port is reached by passing the flag it was started with.

- A wildcard bind (`0.0.0.0` / `::`) is dialed as loopback, since the reload endpoint's local-only variant requires a loopback peer.
- IPv6 literals are bracketed exactly once — `URL.hostname` keeps the brackets, so naively re-adding them produced `[[::1]]`. A unit test caught this.
- `install` prints `reloaded <name>@<version> in the daemon at <url>` when a reload lands, so an upgrade that took effect is visible.
- README regenerated for the new flag.

### Tests

- **`test/cli/challenge-daemon-reload-target.test.ts`** (new): reload-url derivation — non-default port, wildcard bind, IPv6 literal, and urls with no usable port.
- **`test/cli/challenge-integration.test.ts`**: `challenge install --pkcRpcUrl` of `test-challenge@3.0.0` against a daemon on a dynamic port, with **no** `/api/challenges/reload` call anywhere in the test — asserts the install reports the reload and that a publication exercises v3.

Verified red against the hardcoded-url version and green after.

Full suite locally after both fixes: **42 files, 319 passed, 1 skipped**.

### Known gap, not fixed here

`loadChallengesIntoPKC()` only ever *adds* to the registry, so `challenge remove` still leaves the removed factory registered until the daemon restarts. Un-registering safely needs care — `PKC.challenges` *is* pkc-js's built-in registry, so deleting a key that shadowed a built-in (e.g. a package named `question`) would destroy the built-in. Worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Challenge installations and removals now automatically reload the daemon through the configured RPC endpoint.
  - Updated challenge packages are detected and activated without restarting the daemon.
  - Unchanged packages remain cached for faster loading.
  - Removed challenges are cleaned up, built-in challenges can be restored, and failed updates preserve working versions.
  - Supports custom, wildcard, and IPv6 daemon endpoints.

- **Documentation**
  - Updated CLI documentation with the required RPC URL option and revised default daemon log path.

- **Tests**
  - Added coverage for upgrades, reload behavior, caching, hashing, failure handling, and endpoint support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->