### PR TITLE
chore(deps): upgrade @pkcprotocol/pkc-js 0.0.81 -> 0.0.82

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@oclif/plugin-help": "6.2.36",
                 "@oclif/plugin-not-found": "3.2.73",
                 "@oclif/table": "0.5.1",
-                "@pkcprotocol/pkc-js": "0.0.81",
+                "@pkcprotocol/pkc-js": "0.0.82",
                 "dataobject-parser": "1.2.22",
                 "decompress": "4.2.1",
                 "env-paths": "2.2.1",
@@ -5850,9 +5850,9 @@
             }
         },
         "node_modules/@pkcprotocol/pkc-js": {
-            "version": "0.0.81",
-            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.81.tgz",
-            "integrity": "sha512-mUgk+Dg6HPm9xAtPQVB+GBK8WJd8SgGpMg0QhW9aingOzh/jl3uNkJoycOJP7oF4I/L5bkPb19hPZHn8fohM4g==",
+            "version": "0.0.82",
+            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.82.tgz",
+            "integrity": "sha512-65bE+77b6wLrP62owYe1pCq3TEdmaKMRByqii5in/ikyHJpUEYd5dVKe/KFkTWTMV+1+kkMUC+hXgeRdPNIy0w==",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@enhances/with-resolvers": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "@oclif/plugin-help": "6.2.36",
         "@oclif/plugin-not-found": "3.2.73",
         "@oclif/table": "0.5.1",
-        "@pkcprotocol/pkc-js": "0.0.81",
+        "@pkcprotocol/pkc-js": "0.0.82",
         "dataobject-parser": "1.2.22",
         "decompress": "4.2.1",
         "env-paths": "2.2.1",


### PR DESCRIPTION
Closes #126

## What

Bumps `@pkcprotocol/pkc-js` from `0.0.81` to `0.0.82` (latest). Dependency-only change — no source edits.

## Upstream changes

**v0.0.82**

### Features
- **crosspost:** embed the reposted comment in `comment.crosspost` (pkcprotocol/pkc-js#248, closes pkcprotocol/pkc-js#32) — a crossposting comment now carries the full `CommentIpfs` of the comment it reposts, so the crossposting community's mods can moderate it in place. Adds a `noCrossposts` community feature.

### Bug Fixes
- **pkc:** stop in-flight publications in `destroy()` and drain their background community refresh (pkcprotocol/pkc-js#271, closes pkcprotocol/pkc-js#270)

Neither needs CLI plumbing here: community features are passed through generically rather than enumerated in `src/`, so `noCrossposts` is reachable without changes.

## Verification

- `npm run build && npm run build:test` — clean
- `npm run test:cli` — 43 files, 333 passed, 6 skipped

One file (`test/cli/daemon.test.ts`) hit a pre-existing flake on the first full run; it passes on re-run (23/23) and is unrelated to this bump. Details below.

## Follow-up worth a look (not changed here)

`test/helpers/daemon-helpers.ts` retries the TOCTOU port race via `isAddressInUseError`, which matches three signatures:

```
/address already in use|EADDRINUSE|became occupied before the daemon could bind it/i
```

There is a fourth wording it does not cover. `src/ipfs/startIpfs.ts:215` raises the CLI's own pre-bind guard as:

```
Cannot start IPFS daemon because the IPFS Gateway port 0.0.0.0:37685 (configured as /ip4/0.0.0.0/tcp/37685) is already in use.
```

That string contains `is already in use` but not `address already in use`, so the matcher returns false, `startPkcDaemonWithDynamicPorts` rethrows instead of retrying with a fresh port set, and the suite's `beforeAll` dies. Same root cause as issues #87 / #97, just a third message wording — the gateway port, where the earlier fixes covered the raw bind failure and the PKC RPC pre-bind guard.

A second, avoidable failure lands on top: `afterAll` still runs and calls `waitForPortFree(rpcPort, ...)` with `rpcPort` never assigned, so alongside the real startup error the run also reports

```
TypeError: The "options" or "port" or "path" argument must be specified
  at test/helpers/daemon-helpers.ts:198  // socket.connect(port, host)
```

which points at the teardown rather than the lost bind race. Both errors are reported, so the cause is not hidden outright, but the spurious one is the eye-catching part.

Tracked and fixed separately in #128 — this PR stays dependency-only.
