### PR TITLE
test(daemon): retry the bind race when the CLI's own port guard fires

### DIFF
--- a/test/cli/daemon.test.ts
+++ b/test/cli/daemon.test.ts
@@ -232,7 +232,10 @@ describe("bitsocial daemon (kubo daemon is started by bitsocial-cli)", async () 
 
     afterAll(async () => {
         await stopPkcDaemon(daemonProcess);
-        await waitForPortFree(rpcPort, "localhost", 10000);
+        // beforeAll may have thrown before assigning rpcPort (a lost bind race, say). There is no
+        // port to wait on then, and failing here would just stack a teardown error on top of the
+        // real startup one (issue #128).
+        if (rpcPort !== undefined) await waitForPortFree(rpcPort, "localhost", 10000);
     });
 
     it(`PKC RPC server is started`, async () => {

--- a/test/helpers/daemon-helpers.ts
+++ b/test/helpers/daemon-helpers.ts
@@ -178,6 +178,15 @@ export const waitForKuboReady = async (kuboApiUrl: string, timeoutMs = 20000) =>
 };
 
 export const waitForPortFree = async (port: number, host = "localhost", timeoutMs = 20000) => {
+    // A suite whose beforeAll threw still runs its afterAll, so this used to be handed an undefined
+    // port and net.Socket answered with a bare 'The "options" or "port" or "path" argument must be
+    // specified' — a teardown crash reported alongside the real startup error, pointing at the wrong
+    // line. Name the actual cause instead (issue #128).
+    if (!Number.isInteger(port) || port <= 0)
+        throw new Error(
+            `waitForPortFree was called with a non-numeric port (${String(port)}). This usually means the suite's ` +
+                `beforeAll threw before assigning it — fix that failure first, this teardown error is a symptom of it.`
+        );
     return waitForCondition(
         () =>
             new Promise<boolean>((resolve) => {
@@ -254,13 +263,23 @@ export const allocateKuboEndpoints = async (): Promise<KuboEndpoints> => {
 };
 
 // startPkcDaemon rejects with either a string (subprocess exit, carrying captured stdout/stderr)
-// or an Error; the bind-race signature can surface in either. A lost TOCTOU port race shows up two
-// ways: a raw bind failure ("...address already in use" / EADDRINUSE), OR the daemon's own pre-bind
-// guard firing first with "PKC RPC port ... became occupied before the daemon could bind it"
-// (src/cli/commands/daemon.ts). Both mean the same thing — retry with a fresh port set (issue #97).
+// or an Error; the bind-race signature can surface in either. A lost TOCTOU port race reaches us
+// three ways, and all three mean the same thing — retry with a fresh port set (issues #97, #128):
+//
+//   1. A raw bind failure from kubo itself: "...address already in use" / EADDRINUSE.
+//   2. The daemon's RPC pre-bind guard, which races its own check: "PKC RPC port ... became
+//      occupied before the daemon could bind it" (src/cli/commands/daemon.ts).
+//   3. The CLI's port-availability guards, which phrase it as "... port <host>:<port> ... is
+//      already in use" and never say "address": the kubo API / gateway / swarm checks in
+//      src/ipfs/startIpfs.ts and src/cli/commands/daemon.ts, plus the "PKC RPC port is already in
+//      use at <url>" check. Omitting these is what let a lost gateway-port race take down
+//      daemon.test.ts's whole beforeAll instead of being retried (issue #128).
+//
+// Keep the third pattern anchored on "port ... is already in use" rather than a bare "in use" so
+// an unrelated failure that merely mentions a port is still treated as real and rethrown.
 export const isAddressInUseError = (reason: unknown): boolean => {
     const message = typeof reason === "string" ? reason : reason instanceof Error ? reason.message : String(reason);
-    return /address already in use|EADDRINUSE|became occupied before the daemon could bind it/i.test(message);
+    return /address already in use|EADDRINUSE|became occupied before the daemon could bind it|port\b.*\bis already in use/i.test(message);
 };
 
 export type DynamicDaemonResult = KuboEndpoints & { daemonProcess: ManagedChildProcess };

--- a/test/helpers/dynamic-ports.test.ts
+++ b/test/helpers/dynamic-ports.test.ts
@@ -5,7 +5,14 @@
 // allocator and the retry helper directly (no daemon spawn) so they're fast and deterministic.
 import { describe, it, expect } from "vitest";
 import net from "net";
-import { allocateFreePort, allocateKuboEndpoints, isAddressInUseError, withKuboBindRetry, type KuboEndpoints } from "./daemon-helpers.js";
+import {
+    allocateFreePort,
+    allocateKuboEndpoints,
+    isAddressInUseError,
+    waitForPortFree,
+    withKuboBindRetry,
+    type KuboEndpoints
+} from "./daemon-helpers.js";
 
 const isBindable = (port: number, host = "127.0.0.1") =>
     new Promise<boolean>((resolve) => {
@@ -34,6 +41,48 @@ describe("dynamic port allocation helpers (issue #87)", () => {
         expect(isAddressInUseError("listen tcp4 0.0.0.0:50599: bind: address already in use")).toBe(true);
         expect(isAddressInUseError(new Error("EADDRINUSE: address already in use 0.0.0.0:50599"))).toBe(true);
         expect(isAddressInUseError("some unrelated failure")).toBe(false);
+    });
+
+    // Issue #128: the same lost bind race also reaches us through the CLI's own pre-bind guards,
+    // which phrase it as "... port <host>:<port> ... is already in use" and never say "address
+    // already in use". Missing these meant startPkcDaemonWithDynamicPorts rethrew instead of
+    // retrying, so the race surfaced as a hard suite failure (daemon.test.ts's beforeAll).
+    it("isAddressInUseError recognises the CLI's own pre-bind guard wordings (issue #128)", () => {
+        // src/ipfs/startIpfs.ts:215 — one guard, three labels
+        expect(
+            isAddressInUseError(
+                "Cannot start IPFS daemon because the IPFS Gateway port 0.0.0.0:37685 (configured as /ip4/0.0.0.0/tcp/37685) is already in use."
+            )
+        ).toBe(true);
+        expect(
+            isAddressInUseError(
+                "Cannot start IPFS daemon because the IPFS Swarm port 0.0.0.0:41003 (configured as /ip4/0.0.0.0/tcp/41003) is already in use."
+            )
+        ).toBe(true);
+        // src/cli/commands/daemon.ts:416
+        expect(
+            isAddressInUseError(
+                new Error(
+                    "Cannot start IPFS daemon because the IPFS API port 0.0.0.0:34811 (configured as http://0.0.0.0:34811/api/v0) is already in use."
+                )
+            )
+        ).toBe(true);
+        // src/cli/commands/daemon.ts:320
+        expect(
+            isAddressInUseError("PKC RPC port is already in use at ws://localhost:41234/ (another bitsocial daemon is likely running).")
+        ).toBe(true);
+        // Still not a catch-all: an unrelated failure that merely mentions a port must not retry.
+        expect(isAddressInUseError("kubo repo is corrupt (port 41234 was fine)")).toBe(false);
+        expect(isAddressInUseError("could not reach the gateway port 0.0.0.0:37685")).toBe(false);
+    });
+
+    // The second, avoidable failure from issue #128: when beforeAll dies before assigning its port,
+    // afterAll called waitForPortFree(undefined) and net.Socket raised a TypeError about "options"
+    // or "port" — a teardown crash reported next to the real startup error. Name the cause instead.
+    it("waitForPortFree rejects with a cause-naming error when handed no port (issue #128)", async () => {
+        await expect(waitForPortFree(undefined as unknown as number, "localhost", 100)).rejects.toThrow(/waitForPortFree/i);
+        await expect(waitForPortFree(undefined as unknown as number, "localhost", 100)).rejects.toThrow(/beforeAll/i);
+        await expect(waitForPortFree(Number.NaN, "localhost", 100)).rejects.toThrow(/waitForPortFree/i);
     });
 
     it("withKuboBindRetry retries a bind race with fresh endpoints, then succeeds", async () => {


### PR DESCRIPTION
Closes #128

## Problem

`test/cli/daemon.test.ts` intermittently failed its whole file with **zero failed tests** — seen on a full `test:cli` run while verifying #127:

```
Test Files  1 failed | 42 passed (43)
      Tests  333 passed | 6 skipped (339)
```

The real error was the suite's `beforeAll` never getting a daemon up:

```
Daemon failed to start: Cannot start IPFS daemon because the IPFS Gateway port
0.0.0.0:37685 (configured as /ip4/0.0.0.0/tcp/37685) is already in use.
```

next to a spurious teardown crash that pointed at the wrong line:

```
TypeError: The "options" or "port" or "path" argument must be specified
  at test/helpers/daemon-helpers.ts:198   // socket.connect(port, host)
```

## Root cause

The same TOCTOU bind race as #87 / #97, in a wording the retry matcher did not recognise.

`startPkcDaemonWithDynamicPorts` retries only when `isAddressInUseError` agrees, and that matcher covered three signatures — `address already in use`, `EADDRINUSE`, and the RPC guard's `became occupied before the daemon could bind it`. But the CLI's own port-availability guards phrase it differently and never say "address":

| Source | Message |
| --- | --- |
| `src/ipfs/startIpfs.ts:215` | `Cannot start IPFS daemon because the ${label} port ${host}:${port} (configured as ${source}) is already in use.` (IPFS API / Gateway / Swarm) |
| `src/cli/commands/daemon.ts:416` | `Cannot start IPFS daemon because the IPFS API port ... is already in use.` |
| `src/cli/commands/daemon.ts:320` | `PKC RPC port is already in use at ${pkcRpcUrl} ...` |

So the matcher returned `false`, the retry was skipped, and a lost gateway-port race took down the entire suite instead of being absorbed. #87 and #97 had covered the raw bind failure and the RPC pre-bind guard; these were the gap.

The `TypeError` was a second, independent problem: a suite whose `beforeAll` throws still runs its `afterAll`, which called `waitForPortFree(rpcPort, ...)` with `rpcPort` never assigned.

## Changes

1. **`isAddressInUseError`** — added a fourth alternative, `port\b.*\bis already in use`, covering all three guards above. Deliberately anchored on `port ... is already in use` rather than a bare `in use`, so an unrelated failure that merely mentions a port is still treated as real and rethrown.
2. **`waitForPortFree`** — rejects with a message naming the actual cause when handed a non-numeric port, instead of letting `net.Socket` emit a bare `TypeError` about `"options" or "port" or "path"`.
3. **`daemon.test.ts` `afterAll`** — skips the port wait when `beforeAll` never assigned `rpcPort`, so a failed startup reports exactly one error.

## Tests

Added to `test/helpers/dynamic-ports.test.ts` (the existing home for this machinery), written red first — both failed against the unfixed helpers, the second reproducing the exact `TypeError`:

- `isAddressInUseError recognises the CLI's own pre-bind guard wordings (issue #128)` — all four real message shapes, plus two negatives (`kubo repo is corrupt (port 41234 was fine)`, `could not reach the gateway port ...`) pinning that this did not become a catch-all.
- `waitForPortFree rejects with a cause-naming error when handed no port (issue #128)`.

## Safety check

Widening the matcher does not affect the tests that *deliberately* occupy a port and assert failure (`daemon.test.ts:384/394/404`) — those call `runPkcDaemonExpectFailure` directly, not the retry helper. The two other `isAddressInUseError` call sites (`daemon.test.ts:893`, `daemon-kubo-restart-race.test.ts:189`) both check for the intended-path signature before consulting the matcher, so they keep distinguishing a real failure from a race.

## Verification

- `npm run build && npm run build:test` — clean
- `npm run test:cli` — 43 files, 340 passed, 1 skipped
