### PR TITLE
test(daemon-state): isolate the states dir so a parallel daemon's prune can't delete test files

### DIFF
--- a/test/common-utils/daemon-state.test.ts
+++ b/test/common-utils/daemon-state.test.ts
@@ -3,23 +3,42 @@ import fs from "fs/promises";
 import path from "path";
 import { spawn, type ChildProcess } from "child_process";
 import { once } from "events";
+import { pathToFileURL } from "url";
 import { directory as randomDirectory } from "tempy";
-import defaults from "../../dist/common-utils/defaults.js";
-
-// We test the functions by importing them, but they use a hardcoded DAEMON_STATES_DIR.
-// To isolate tests, we test the logic directly with a custom dir via the module internals.
-// Since the module uses a fixed path, we'll test by writing/reading actual state files
-// in the real states dir, then cleaning up.
-
-// Import the actual functions
-import {
-    writeDaemonState,
-    readAllDaemonStates,
-    deleteDaemonState,
-    getAliveDaemonStates,
-    pruneStaleStates
-} from "../../dist/common-utils/daemon-state.js";
 import type { DaemonState } from "../../dist/common-utils/daemon-state.js";
+
+// These tests exercise the real dist module by writing and reading actual state files, and that module
+// resolves its states dir ONCE, at import time, from env-paths' data dir (daemon-state.ts:
+// DAEMON_STATES_DIR). Left at its default, that dir is machine-global — shared with every daemon on the
+// box, including those other test files start in parallel, each of which prunes dead-pid state files on
+// startup and so deletes the synthetic dead-pid ones written here (issue #130). So point the data dir at
+// a tempdir. Because both PKC_DATA_PATH and DAEMON_STATES_DIR are computed eagerly at module load, the
+// override has to happen BEFORE the dist modules are imported — hence the dynamic imports below.
+// env-paths derives the data dir from XDG_DATA_HOME on linux, HOME on macOS and LOCALAPPDATA on
+// windows, so all of them are overridden.
+const isolatedHome = randomDirectory();
+
+/**
+ * The data-dir env as the rest of the machine sees it, captured before the override, so a spawned
+ * pruner can be pointed at the REAL shared dir (see runExternalPrune). Keys with an undefined value are
+ * dropped from a child's env by child_process, which correctly restores "was never set".
+ */
+const REAL_DATA_DIR_ENV: NodeJS.ProcessEnv = {
+    HOME: process.env["HOME"],
+    XDG_DATA_HOME: process.env["XDG_DATA_HOME"],
+    LOCALAPPDATA: process.env["LOCALAPPDATA"],
+    APPDATA: process.env["APPDATA"]
+};
+
+process.env["HOME"] = isolatedHome;
+process.env["XDG_DATA_HOME"] = path.join(isolatedHome, ".local", "share");
+process.env["LOCALAPPDATA"] = path.join(isolatedHome, "AppData", "Local");
+process.env["APPDATA"] = path.join(isolatedHome, "AppData", "Roaming");
+
+const { writeDaemonState, readAllDaemonStates, deleteDaemonState, getAliveDaemonStates, pruneStaleStates } = await import(
+    "../../dist/common-utils/daemon-state.js"
+);
+const { default: defaults } = await import("../../dist/common-utils/defaults.js");
 
 // Use a PID range that definitely doesn't exist (very large PIDs)
 const FAKE_PID_BASE = 9999900;
@@ -32,6 +51,23 @@ const makeState = (pid: number): DaemonState => ({
     argv: ["--pkcRpcUrl", `ws://localhost:${9000 + pid}`],
     pkcRpcUrl: `ws://localhost:${9000 + pid}`
 });
+
+const DAEMON_STATE_MODULE = pathToFileURL(path.join(process.cwd(), "dist", "common-utils", "daemon-state.js")).href;
+
+/**
+ * Run `pruneStaleStates()` in a separate process against the machine-global states dir — exactly what
+ * a `bitsocial daemon` startup in a parallel test file does (daemon.ts calls it on startup), and what
+ * deleted this file's state files mid-test before the dir was isolated (issue #130). Touching the shared
+ * dir is safe: it removes only files whose pid is dead, the same best-effort cleanup any daemon does.
+ */
+const runExternalPrune = async (): Promise<void> => {
+    const proc = spawn(process.execPath, ["-e", `import('${DAEMON_STATE_MODULE}').then((m) => m.pruneStaleStates())`], {
+        stdio: "ignore",
+        env: { ...process.env, ...REAL_DATA_DIR_ENV }
+    });
+    const [exitCode] = (await once(proc, "close")) as [number | null];
+    expect(exitCode).toBe(0);
+};
 
 describe("daemon-state", () => {
     const createdPids: number[] = [];
@@ -57,6 +93,25 @@ describe("daemon-state", () => {
             expect(found).toBeDefined();
             expect(found!.argv).toEqual(state.argv);
             expect(found!.pkcRpcUrl).toBe(state.pkcRpcUrl);
+        });
+
+        // Regression test for https://github.com/bitsocialnet/bitsocial-cli/issues/130
+        // These tests write state files for synthetic DEAD pids, and the states dir the dist module
+        // resolves at import time used to be the machine-global one every daemon shares. Any daemon
+        // starting in a parallel test file prunes that dir on startup (daemon.ts -> pruneStaleStates),
+        // and a dead pid is exactly what it deletes — so this file's files vanished mid-test. It
+        // surfaced on Windows CI, whose slower timing widens the window: "should write multiple state
+        // files" failed with `expected [ 9999903 ] to include 9999902`, pid1's file pruned between the
+        // two writes and the read.
+        it("keeps its own state file when another daemon prunes the shared states dir", async () => {
+            const pid = nextFakePid();
+            createdPids.push(pid);
+            await writeDaemonState(makeState(pid));
+
+            await runExternalPrune();
+
+            const all = await readAllDaemonStates();
+            expect(all.map((s) => s.pid)).toContain(pid);
         });
 
         it("should write multiple state files", async () => {

--- a/test/common-utils/daemon-supervisor.test.ts
+++ b/test/common-utils/daemon-supervisor.test.ts
@@ -1,13 +1,23 @@
 import { describe, it, expect, afterEach } from "vitest";
-import {
-    parseSystemdUnitFromCgroup,
-    detectSelfSupervisor,
-    resolveDaemonSupervisor,
-    writeDaemonState,
-    readAllDaemonStates,
-    deleteDaemonState
-} from "../../dist/common-utils/daemon-state.js";
+import path from "path";
+import { directory as randomDirectory } from "tempy";
 import type { DaemonState, DaemonSupervisor } from "../../dist/common-utils/daemon-state.js";
+
+// Isolate the daemon states dir (issue #130): the round-trip tests below write state files for
+// synthetic DEAD pids, and the dist module resolves its states dir once, at import time, from
+// env-paths' data dir. Left at its default that dir is machine-global, and every daemon prunes
+// dead-pid files there on startup — including daemons other test files start in parallel, which
+// would delete these files mid-test. The override must precede the import (PKC_DATA_PATH and
+// DAEMON_STATES_DIR are both computed eagerly), hence the dynamic import. See
+// test/common-utils/daemon-state.test.ts for the full story and its regression test.
+const isolatedHome = randomDirectory();
+process.env["HOME"] = isolatedHome;
+process.env["XDG_DATA_HOME"] = path.join(isolatedHome, ".local", "share");
+process.env["LOCALAPPDATA"] = path.join(isolatedHome, "AppData", "Local");
+process.env["APPDATA"] = path.join(isolatedHome, "AppData", "Roaming");
+
+const { parseSystemdUnitFromCgroup, detectSelfSupervisor, resolveDaemonSupervisor, writeDaemonState, readAllDaemonStates, deleteDaemonState } =
+    await import("../../dist/common-utils/daemon-state.js");
 
 // Supervisor detection/resolution for issue #82. The parser is pure; detect/resolve take an
 // injectable cgroup reader so we never depend on the test runner's own cgroup.


### PR DESCRIPTION
Closes #130

## Problem

Windows CI on #129 failed a test that branch does not touch:

```
FAIL test/common-utils/daemon-state.test.ts > writeDaemonState + readAllDaemonStates
     > should write multiple state files
AssertionError: expected [ 9999903 ] to include 9999902
```

Ubuntu and macOS passed. Note the actual array: pid2's file is there, pid1's is **gone**. Nothing failed to write — something deleted pid1's file in the 76 ms between `writeDaemonState(pid1)` and `readAllDaemonStates()`.

## Root cause

`src/common-utils/daemon-state.ts:9` resolves the states dir **once, at import time**, from env-paths' data dir:

```ts
const DAEMON_STATES_DIR = path.join(defaults.PKC_DATA_PATH, ".daemon_states");
```

The test imports that dist module in-process without overriding the env, so — unlike `update-install-restart-race.test.ts` / `update-install-systemd-aware.test.ts`, which override `HOME`/`XDG_DATA_HOME` for the children they spawn — its state files land in the **machine-global** `.daemon_states` dir every daemon shares. And the pids it writes (`FAKE_PID_BASE = 9999900`) are deliberately dead.

Meanwhile `fileParallelism: true` runs other files concurrently, and every daemon startup prunes that shared dir: `src/cli/commands/daemon.ts:349` → `pruneStaleStates()` → `getAliveDaemonStates()`, which unlinks the state file of any pid that is not alive. A synthetic `9999xxx` pid is exactly that.

The log timing confirms the overlap: when the assertion fired at 06:42:56, `daemon.test.ts` (finished 06:43:11) and `challenge.test.ts` (06:43:00) were both mid-flight starting daemons. Windows-only in practice because it is ~3-4x slower there, which widens the window; the race is latent on Linux and macOS too.

Distinct from #94 / #75, which hardened the daemon against *losing* the prune race and skipped the pid-reuse tests on Windows — neither stopped these tests from being pruned out from under themselves.

## Changes

1. **`daemon-state.test.ts`** — point `HOME` / `XDG_DATA_HOME` / `LOCALAPPDATA` / `APPDATA` at a tempdir (env-paths reads a different one per platform: `XDG_DATA_HOME` on linux, `HOME` on macOS, `LOCALAPPDATA` on windows). Since `PKC_DATA_PATH` and `DAEMON_STATES_DIR` are both computed eagerly at module load, the override has to precede the import — so the two dist imports become dynamic. The type-only import stays static (erased at compile time).
2. **`daemon-supervisor.test.ts`** — same hazard at its `writeDaemonState` round-trip tests (fake pids 9999700/9999701 in the shared dir), same isolation.

## Tests

`keeps its own state file when another daemon prunes the shared states dir` reproduces the race deterministically instead of hoping to catch it: it writes a state file, then runs `pruneStaleStates()` in a spawned process carrying the **real, un-isolated** env — exactly what a daemon starting in a parallel test file does — and asserts the file survives.

- Red before the isolation, with the same failure mode as CI: `expected [] to include 9999902`
- Green after

It is also a standing guard: reverting the isolation makes it fail deterministically on every platform, not just under a lost race on Windows.

The captured real env is stored before the override; `child_process` drops env keys whose value is `undefined`, so a var that was never set stays unset in the child. Running the pruner against the shared dir is safe — it removes only dead-pid files, the same best-effort cleanup any daemon start performs.

## Verification

- `npm run build && npm run build:test` — clean
- `npm run test:cli` — 43 files, 339 passed, 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved daemon-state test isolation by using temporary, platform-specific data directories.
  - Added regression coverage to ensure one daemon’s cleanup does not remove another daemon’s valid state.
  - Prevented daemon supervisor tests from sharing machine-global state files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->