### PR TITLE
chore(deps): upgrade @pkcprotocol/pkc-js 0.0.82 -> 0.0.83

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@oclif/plugin-help": "6.2.36",
                 "@oclif/plugin-not-found": "3.2.73",
                 "@oclif/table": "0.5.1",
-                "@pkcprotocol/pkc-js": "0.0.82",
+                "@pkcprotocol/pkc-js": "0.0.83",
                 "dataobject-parser": "1.2.22",
                 "decompress": "4.2.1",
                 "env-paths": "2.2.1",
@@ -5850,9 +5850,9 @@
             }
         },
         "node_modules/@pkcprotocol/pkc-js": {
-            "version": "0.0.82",
-            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.82.tgz",
-            "integrity": "sha512-65bE+77b6wLrP62owYe1pCq3TEdmaKMRByqii5in/ikyHJpUEYd5dVKe/KFkTWTMV+1+kkMUC+hXgeRdPNIy0w==",
+            "version": "0.0.83",
+            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.83.tgz",
+            "integrity": "sha512-vh6N/7hheXr7hmxLjn0GIsP6hPYkEg/ya96Q5ECjVV8Qy3Av6gJ92/k4TecjVC0C0NCHs/g77jYeWXHCNvgGSA==",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@enhances/with-resolvers": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "@oclif/plugin-help": "6.2.36",
         "@oclif/plugin-not-found": "3.2.73",
         "@oclif/table": "0.5.1",
-        "@pkcprotocol/pkc-js": "0.0.82",
+        "@pkcprotocol/pkc-js": "0.0.83",
         "dataobject-parser": "1.2.22",
         "decompress": "4.2.1",
         "env-paths": "2.2.1",

--- a/test/cli/daemon.test.ts
+++ b/test/cli/daemon.test.ts
@@ -753,9 +753,13 @@ describe(`bitsocial daemon KUBO_RPC_URL env var`, async () => {
         try {
             const daemon = await startPkcDaemonWithDynamicPorts((e) => ["--pkcOptions.dataPath", randomDirectory(), "--pkcRpcUrl", e.rpcWsUrl]);
             daemonProcess = daemon.daemonProcess;
-            // Kubo should be reachable on the port configured via the injected KUBO_RPC_URL env var
-            const res = await fetch(`${daemon.kuboApiUrl}/bitswap/stat`, { method: "POST" });
-            expect(res.status).toBe(200);
+            // Kubo should be reachable on the port configured via the injected KUBO_RPC_URL env var.
+            // Poll instead of a one-shot fetch: startPkcDaemon resolves on the "Communities in data
+            // path" banner, but pkc-js restarts kubo around init (it rewrites the Routing config and
+            // POSTs /shutdown on first connect), so a single fetch can land in the window where the
+            // API port refuses connections (issue #133, lineage #95).
+            const kuboReady = await waitForKuboReady(daemon.kuboApiUrl, 45000);
+            expect(kuboReady).toBe(true);
         } finally {
             await stopPkcDaemon(daemonProcess);
         }


### PR DESCRIPTION
Bumps `@pkcprotocol/pkc-js` from 0.0.82 to 0.0.83 (latest on npm).

Lockfile diff touches only pkc-js itself — no transitive dependency changes.

Also fixes a pre-existing test flake that surfaced on this branch's first CI run (macOS): `daemon uses KUBO_RPC_URL env var to configure kubo bind address` verified kubo with a single un-retried `fetch` that can land in the window where pkc-js has restarted kubo around init. Now polls `waitForKuboReady`, like every other kubo check in the suite. Not caused by the version bump.

Closes #133

## Verification

- `npm run build && npm run build:test` — clean
- `npm run test:cli` — 43 files, 341 passed, 1 skipped, 0 failed