### PR TITLE
chore(deps): upgrade @pkcprotocol/pkc-js 0.0.83 -> 0.0.85

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@oclif/plugin-help": "6.2.36",
                 "@oclif/plugin-not-found": "3.2.73",
                 "@oclif/table": "0.5.1",
-                "@pkcprotocol/pkc-js": "0.0.83",
+                "@pkcprotocol/pkc-js": "0.0.85",
                 "dataobject-parser": "1.2.22",
                 "decompress": "4.2.1",
                 "env-paths": "2.2.1",
@@ -5850,9 +5850,9 @@
             }
         },
         "node_modules/@pkcprotocol/pkc-js": {
-            "version": "0.0.83",
-            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.83.tgz",
-            "integrity": "sha512-vh6N/7hheXr7hmxLjn0GIsP6hPYkEg/ya96Q5ECjVV8Qy3Av6gJ92/k4TecjVC0C0NCHs/g77jYeWXHCNvgGSA==",
+            "version": "0.0.85",
+            "resolved": "https://registry.npmjs.org/@pkcprotocol/pkc-js/-/pkc-js-0.0.85.tgz",
+            "integrity": "sha512-6fC0VODN7omo6tYoXSds3qp+fclULQRwLFeSP7e6ZKfLV8rt5S2efd6qSTaPWZujHrWwFRl42B3wb9sA9DTn4A==",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@enhances/with-resolvers": "0.0.5",
@@ -5873,8 +5873,8 @@
                 "assert": "2.1.0",
                 "better-sqlite3": "12.9.0",
                 "blockstore-core": "7.0.1",
-                "blockstore-fs": "^4.0.1",
-                "blockstore-idb": "^4.0.1",
+                "blockstore-fs": "4.0.1",
+                "blockstore-idb": "4.0.1",
                 "buffer": "6.0.3",
                 "cbor": "10.0.11",
                 "cborg": "4.5.8",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "@oclif/plugin-help": "6.2.36",
         "@oclif/plugin-not-found": "3.2.73",
         "@oclif/table": "0.5.1",
-        "@pkcprotocol/pkc-js": "0.0.83",
+        "@pkcprotocol/pkc-js": "0.0.85",
         "dataobject-parser": "1.2.22",
         "decompress": "4.2.1",
         "env-paths": "2.2.1",

--- a/test/cli/mintpass-integration.test.ts
+++ b/test/cli/mintpass-integration.test.ts
@@ -178,7 +178,20 @@ describe.skipIf(process.platform === "win32")("@bitsocial/mintpass-challenge int
         const sub = await pkc.createCommunity();
         await sub.edit({
             settings: {
-                challenges: [{ name: "@bitsocial/mintpass-challenge" }]
+                challenges: [
+                    {
+                        name: "@bitsocial/mintpass-challenge",
+                        // pkc-js >= 0.0.85 validates settings.challenges against each challenge file's
+                        // optionInputs, and mintpass marks these three `required`. `default` there is a UI
+                        // hint that core never applies, so they have to be passed explicitly. The values
+                        // match the package's own runtime fallbacks, so challenge behaviour is unchanged.
+                        options: {
+                            chainTicker: "base",
+                            contractAddress: "0x13d41d6B8EA5C86096bb7a94C3557FCF184491b9",
+                            requiredTokenType: "0"
+                        }
+                    }
+                ]
             }
         });
         await sub.start();


### PR DESCRIPTION
Closes #134

## What

Bumps `@pkcprotocol/pkc-js` from `0.0.83` to `0.0.85` (latest on npm). Lockfile diff touches only pkc-js itself — no transitive dependency changes.

## Upstream changes

**v0.0.84**
- feat(pkc): cancel in-flight community fetches via `abortSignal`, `publication.stop()` and `destroy()` (pkcprotocol/pkc-js#276)

**v0.0.85**
- feat(challenges): add `validateChallengeSettings` and core `optionInputs` validation (pkcprotocol/pkc-js#288)
- feat(challenges): publish opt-in public challenge options in the community record (pkcprotocol/pkc-js#287)

## The one source change

0.0.85 validates `settings.challenges[]` against each challenge file's `optionInputs` on the edit, community-creation and start paths. That surfaced a genuinely invalid config in `test/cli/mintpass-integration.test.ts`, which configured the challenge with no options at all:

```ts
challenges: [{ name: "@bitsocial/mintpass-challenge" }]
```

`@bitsocial/mintpass-challenge` declares `chainTicker`, `contractAddress` and `requiredTokenType` as `required: true`. In pkc-js, `required` means *present in settings* and `default` in `optionInputs` is a UI hint that core never applies (`runtime/node/community/challenges/validate-challenge-settings.js`), so `edit()` now throws `ERR_CHALLENGE_REQUIRED_OPTION_MISSING`, aggregated into `ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED_FOR_CHALLENGES`.

Fixed by passing the three options explicitly. The values are the package's own runtime fallbacks (`dist/mintpass.js:435` destructures `chainTicker = "base"`, `requiredTokenType = "0"`, and falls back to `DEFAULT_CONTRACTS[chainTicker]` for the address), so **challenge behaviour is unchanged** — the test was relying on those fallbacks implicitly and now states them.

No other call site is affected: the remaining challenges used in tests (`question`, `test-challenge`, `captcha-canvas-v3`) either declare no required `optionInputs` or already pass their options.

## Operational note for existing communities

Worth knowing before this ships to a live daemon: any community whose persisted challenge config has a typo'd/undeclared option key, a missing `required` option, or an undeclared `publicOptions` entry will now emit one `error` event **per invalid challenge on every start**, carrying `{challengeIndex, challengeName, communityAddress}`. The community still starts — a persisted bad config never takes startup down — but the errors are new and will look like a regression to whoever sees them first. A subsequent `community edit` on such a community will throw until the config is corrected.

## Verification

- `npm run build && npm run build:test` — clean
- `npm run test:cli` — 43 files, **341 passed**, 1 skipped, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the PKC protocol integration to a newer version.
  * Improved mint pass challenge configuration with explicit blockchain, contract, and token type settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->