### PR TITLE
ci: install the packed tarball to the fast volume on windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,7 @@ on:
       - 'config/**'
       - 'ci-bin/**'
       - 'ci-bin/*'
+      - '.github/**'
       - 'package.json'
       - 'package-lock.json'
       - 'Dockerfile'
@@ -69,18 +70,42 @@ jobs:
       - run: npm run build
       - run: npx oclif manifest
 
+      # Windows defaults the npm global prefix to C:\npm\prefix, on the OS
+      # volume. Installing this package's ~1386 dependencies there took ~9m,
+      # while `npm ci` writes a larger tree (2054 packages) to the workspace on
+      # D:, the runner's fast volume, in ~55s. That gap repeatedly pushed the
+      # job past timeout-minutes, and a cancelled CI run on master silently
+      # skips CI-build.yml, so no release is published (issue #136).
+      #
+      # Measured on windows-latest, same warm cache, only the destination
+      # differing: C: 9.1m, D: 1.4m, and a plain non-global install on D: 1.0m.
+      # Resolution (12s), postinstall scripts, npm version and the network were
+      # each ruled out first - `--offline` succeeds in ~10m, so none of the cost
+      # was registry traffic.
+      #
+      # setup-node exports npm_config_prefix, which takes precedence over
+      # `npm config set prefix`, so the env var itself has to be overridden.
+      - name: Put the npm global prefix on the fast volume (windows)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          mkdir -p /d/npm-global
+          echo 'npm_config_prefix=D:\npm-global' >> $GITHUB_ENV
+          echo 'D:\npm-global' >> $GITHUB_PATH
+
       - name: Verify global install from pack
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "npm global prefix: $(npm config get prefix)"
           TARBALL=$(npm pack | tail -1)
           # Retry: the kubo postinstall downloads its binary from dist.ipfs.tech,
           # which intermittently returns 5xx and aborts the install with no retry
           # of its own (issue #110).
-          # --prefer-offline reuses the cache primed by `npm ci` above, which
-          # skips the registry round trips that made this step take 17m on
-          # Windows and blow the job timeout.
+          # --prefer-offline reuses the cache primed by `npm ci` above. Note it
+          # is not what makes this step fast - see #136; the destination volume
+          # is. Kept because reusing the cache is still the right default.
           for attempt in 1 2 3; do
             npm install -g --prefer-offline --no-audit --no-fund "./$TARBALL" && break
             echo "global install attempt $attempt failed; retrying in 15s..."


### PR DESCRIPTION
Closes #136

## Problem

The windows job intermittently hit `timeout-minutes: 20` inside **Verify global install from pack**, before running a single test. When that happened on a `master` push, `CI-build.yml` — gated on `if: github.event.workflow_run.conclusion == 'success'` — was **skipped**, so no release was published. It silently blocked the pkc-js 0.0.85 release yesterday.

The step has been chronically slow, not newly slow. Across the last 40 CI runs:

| | |
|---|---|
| step duration, windows | **8–13m**, going back to at least 2026-06-25 |
| same tree via `npm ci`, same job, same runner | **~55s** (and a *larger* tree: 2054 packages vs 1386) |
| whole test suite | 2.5m |
| job cap | 20m |

Prior timeouts: 2026-07-30 (`0382b13`), 2026-08-13 (`53b42e5`), 2026-08-21 (`0f6ef94`).

## Cause

The destination volume. Windows defaults the npm global prefix to `C:\npm\prefix` on the OS disk; `npm ci` writes to the workspace on `D:`, the runner's fast volume.

Measured on `windows-latest`, identical warm cache, `max-parallel: 1`, varying only the destination:

| Destination | Time |
| --- | --- |
| `C:\npm\prefix` (current default) | **9.1m** |
| `D:\npm-global` | **1.4m** |
| `D:`, plain non-global install | **1.0m** |

Everything else was ruled out first, each with a measurement rather than a guess:

- **Resolution** — dry-run resolve is **12s** on windows.
- **Postinstall scripts** — `--ignore-scripts` is no faster (8.3m).
- **npm version** — 12.0.2 is no faster (10.8m); the workflow pins 11.13.0.
- **Network** — `--offline` **succeeds, exit 0**, in ~10m. With no registry access at all the step is just as slow, so none of the cost is registry traffic.

## The fix

`setup-node` exports `npm_config_prefix`, which takes precedence over `npm config set prefix` — an earlier attempt to move the prefix silently did nothing and had to be redone against the env var. So the env var itself is overridden, and `D:\npm-global` is added to `PATH` so `bitsocial --version` still resolves.

## Two notes on the existing workflow

**`--prefer-offline` never fixed this.** `ff6aa9b` added it right after the 2026-07-30 timeout and its comment credits it with fixing a 17m step. Median step time was **~10.0m before** and **~10.7m after** — it was credited with a 17.1m outlier in an already-noisy distribution. The flag is kept (reusing the cache is still correct) but its comment no longer claims to be the fix.

**`.github/**` added to `pull_request` paths.** Without it, a PR touching only a workflow does not run CI — meaning this very change could not have been tested by its own PR.

## Verification

The windows job on this PR is the test: the step should drop from ~9m to ~1.5m, and `bitsocial --version` must still resolve from the relocated prefix.

Raising `timeout-minutes` was deliberately not the fix — a step taking 9 minutes to install a tree `npm ci` installs in 55 seconds is the actual defect. With this change the windows job should land around 6-7m, restoring real headroom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * CI now runs for changes to workflow configuration.
  * Improved Windows package installation verification by configuring the global npm location.
  * Added clearer verification output and explanations for offline cache usage and installation performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->